### PR TITLE
ConnectionPool: reconnect immediately after a soft SERVER_ERROR

### DIFF
--- a/include/Connection.h
+++ b/include/Connection.h
@@ -26,7 +26,6 @@ class Connection {
     void close();
     const bool alive();
     bool tryReconnect();
-    void markDead(const char* reason);
     void markDead(const char* reason, int delay);
     int socketFd() const;
 
@@ -53,6 +52,7 @@ class Connection {
 
     void reset();
     static void setRetryTimeout(int timeout);
+    static const int getRetryTimeout();
     static void setConnectTimeout(int timeout);
 
     size_t m_counter;
@@ -101,6 +101,12 @@ inline const uint32_t Connection::port() {
 inline const uint32_t Connection::weight() {
   return m_weight;
 }
+
+
+inline const int Connection::getRetryTimeout() {
+  return s_retryTimeout;
+}
+
 
 } // namespace mc
 } // namespace douban

--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -44,8 +44,8 @@ class ConnectionPool {
   static void setPollTimeout(int timeout);
 
  protected:
-  void markDeadAll(pollfd_t* pollfds, const char*, int delay = 0);
-  void markDeadConn(Connection*, const char*, pollfd_t*);
+  void markDeadAll(pollfd_t* pollfds, const char*, int delay);
+  void markDeadConn(Connection* conn, const char* reason, pollfd_t* fd_ptr, int delay);
 
   uint32_t m_nActiveConn; // wait for poll
   uint32_t m_nInvalidKey;

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -185,12 +185,6 @@ bool Connection::tryReconnect() {
   return m_alive;
 }
 
-
-void Connection::markDead(const char* reason) {
-  return markDead(reason, s_retryTimeout);
-}
-
-
 void Connection::markDead(const char* reason, int delay) {
   if (m_alive) {
     time(&m_deadUntil);

--- a/src/ConnectionPool.cpp
+++ b/src/ConnectionPool.cpp
@@ -467,7 +467,7 @@ err_code_t ConnectionPool::waitPoll() {
               break;
             case RET_MC_SERVER_ERR:
               // soft server error
-              markDeadConn(conn, keywords::kSERVER_ERROR, pollfd_ptr, Connection::getRetryTimeout());
+              markDeadConn(conn, keywords::kSERVER_ERROR, pollfd_ptr, 0);
               ret_code = RET_MC_SERVER_ERR;
               m_nActiveConn -= 1;
               goto next_fd;

--- a/src/ConnectionPool.cpp
+++ b/src/ConnectionPool.cpp
@@ -369,6 +369,7 @@ err_code_t ConnectionPool::waitPoll() {
     if (m_nInvalidKey > 0) {
       return RET_INVALID_KEY_ERR;
     } else {
+      // hard server error
       return RET_MC_SERVER_ERR;
     }
   }
@@ -393,13 +394,13 @@ err_code_t ConnectionPool::waitPoll() {
   while (m_nActiveConn) {
     int rv = poll(pollfds, n_fds, s_pollTimeout);
     if (rv == -1) {
-      markDeadAll(pollfds, keywords::kPOLL_ERROR);
+      markDeadAll(pollfds, keywords::kPOLL_ERROR, 0);
       ret_code = RET_POLL_ERR;
       break;
     } else if (rv == 0) {
       log_warn("poll timeout. (m_nActiveConn: %d)", m_nActiveConn);
       // NOTE: MUST reset all active TCP connections after timeout.
-      markDeadAll(pollfds, keywords::kPOLL_TIMEOUT);
+      markDeadAll(pollfds, keywords::kPOLL_TIMEOUT, 0);
       ret_code = RET_POLL_TIMEOUT_ERR;
       break;
     } else {
@@ -409,7 +410,7 @@ err_code_t ConnectionPool::waitPoll() {
         Connection* conn = fd2conn[fd_idx];
 
         if (pollfd_ptr->revents & (POLLERR | POLLHUP | POLLNVAL)) {
-          markDeadConn(conn, keywords::kCONN_POLL_ERROR, pollfd_ptr);
+          markDeadConn(conn, keywords::kCONN_POLL_ERROR, pollfd_ptr, Connection::getRetryTimeout());
           ret_code = RET_CONN_POLL_ERR;
           m_nActiveConn -= 1;
           goto next_fd;
@@ -420,7 +421,7 @@ err_code_t ConnectionPool::waitPoll() {
           // POLLOUT send
           ssize_t nToSend = conn->send();
           if (nToSend == -1) {
-            markDeadConn(conn, keywords::kSEND_ERROR, pollfd_ptr);
+            markDeadConn(conn, keywords::kSEND_ERROR, pollfd_ptr, Connection::getRetryTimeout());
             ret_code = RET_SEND_ERR;
             m_nActiveConn -= 1;
             goto next_fd;
@@ -444,7 +445,7 @@ err_code_t ConnectionPool::waitPoll() {
           // POLLIN recv
           ssize_t nRecv = conn->recv();
           if (nRecv == -1 || nRecv == 0) {
-            markDeadConn(conn, keywords::kRECV_ERROR, pollfd_ptr);
+            markDeadConn(conn, keywords::kRECV_ERROR, pollfd_ptr, Connection::getRetryTimeout());
             ret_code = RET_RECV_ERR;
             m_nActiveConn -= 1;
             goto next_fd;
@@ -459,13 +460,14 @@ err_code_t ConnectionPool::waitPoll() {
             case RET_INCOMPLETE_BUFFER_ERR:
               break;
             case RET_PROGRAMMING_ERR:
-              markDeadConn(conn, keywords::kPROGRAMMING_ERROR, pollfd_ptr);
+              markDeadConn(conn, keywords::kPROGRAMMING_ERROR, pollfd_ptr, Connection::getRetryTimeout());
               ret_code = RET_PROGRAMMING_ERR;
               m_nActiveConn -= 1;
               goto next_fd;
               break;
             case RET_MC_SERVER_ERR:
-              markDeadConn(conn, keywords::kSERVER_ERROR, pollfd_ptr);
+              // soft server error
+              markDeadConn(conn, keywords::kSERVER_ERROR, pollfd_ptr, Connection::getRetryTimeout());
               ret_code = RET_MC_SERVER_ERR;
               m_nActiveConn -= 1;
               goto next_fd;
@@ -586,8 +588,8 @@ void ConnectionPool::markDeadAll(pollfd_t* pollfds, const char* reason, int dela
 }
 
 
-void ConnectionPool::markDeadConn(Connection* conn, const char* reason, pollfd_t* fd_ptr) {
-  conn->markDead(reason);
+void ConnectionPool::markDeadConn(Connection* conn, const char* reason, pollfd_t* fd_ptr, int delay) {
+  conn->markDead(reason, delay);
   fd_ptr->events = ~POLLOUT & ~POLLIN;
   fd_ptr->fd = conn->socketFd();
 }

--- a/tests/shabby/gevent_issue.py
+++ b/tests/shabby/gevent_issue.py
@@ -9,16 +9,16 @@ greenify.greenify()
 import libmc
 assert greenify.patch_lib(libmc._client.__file__)
 mc = libmc.Client(["127.0.0.1:%d" % slow_memcached_server.PORT])
-mc.config(libmc._client.MC_POLL_TIMEOUT, 3000)  # ms
+mc.config(libmc._client.MC_POLL_TIMEOUT,
+          slow_memcached_server.BLOCKING_SECONDS * 1000 * 2)  # ms
 
 
 stack = []
 
 
-def mc_sleep(seconds=3):
+def mc_sleep():
     print 'begin mc sleep'
     stack.append('mc_sleep_begin')
-    # fake slow memcached server wil return in 2 seconds
     assert mc.set('foo', 'bar'), "Run `python slow_memcached_server.py` first"
     stack.append('mc_sleep_end')
     print 'end mc sleep'

--- a/tests/shabby/reconnect_delay.py
+++ b/tests/shabby/reconnect_delay.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+
+import os
+import time
+import libmc
+import slow_memcached_server
+import subprocess
+
+
+def memcached_server_ctl(cmd, port):
+    ctl_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__)
+        ))),
+        'misc', 'memcached_server'
+    )
+    print ctl_path
+    subprocess.check_call([ctl_path, cmd, str(port)])
+
+
+def test_soft_server_error():
+    mc = libmc.Client(["127.0.0.1:%d" % slow_memcached_server.PORT])
+    mc.config(libmc._client.MC_POLL_TIMEOUT,
+              slow_memcached_server.BLOCKING_SECONDS * 1000 * 2)  # ms
+
+    RETRY_TIMEOUT = 2
+    mc.config(libmc.MC_RETRY_TIMEOUT, RETRY_TIMEOUT)
+
+    assert mc.set('foo', 1)
+    assert not mc.set(slow_memcached_server.KEY_SET_SERVER_ERROR, 1)
+    assert not mc.set('foo', 1)  # still fail
+    time.sleep(RETRY_TIMEOUT / 2)
+    assert not mc.set('foo', 1)  # still fail
+    time.sleep(RETRY_TIMEOUT + 1)
+    assert mc.set('foo', 1)  # back to live
+
+
+def test_hard_server_error():
+    normal_port = 21211
+    mc = libmc.Client(["127.0.0.1:%d" % normal_port])
+
+    RETRY_TIMEOUT = 2
+    mc.config(libmc.MC_RETRY_TIMEOUT, RETRY_TIMEOUT)
+
+    assert mc.set('foo', 1)
+    memcached_server_ctl('stop', normal_port)
+    assert not mc.set('foo', 1)  # still fail
+    memcached_server_ctl('start', normal_port)
+    time.sleep(RETRY_TIMEOUT / 2)
+    assert not mc.set('foo', 1)  # still fail
+    time.sleep(RETRY_TIMEOUT + 1)
+    assert mc.set('foo', 1)  # back to live
+    memcached_server_ctl('stop', normal_port)
+
+
+def main():
+    test_soft_server_error()
+    test_hard_server_error()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/shabby/reconnect_delay.py
+++ b/tests/shabby/reconnect_delay.py
@@ -28,11 +28,11 @@ def test_soft_server_error():
 
     assert mc.set('foo', 1)
     assert not mc.set(slow_memcached_server.KEY_SET_SERVER_ERROR, 1)
-    assert not mc.set('foo', 1)  # still fail
-    time.sleep(RETRY_TIMEOUT / 2)
-    assert not mc.set('foo', 1)  # still fail
-    time.sleep(RETRY_TIMEOUT + 1)
     assert mc.set('foo', 1)  # back to live
+    time.sleep(RETRY_TIMEOUT / 2)
+    assert mc.set('foo', 1)  # alive
+    time.sleep(RETRY_TIMEOUT + 1)
+    assert mc.set('foo', 1)  # alive
 
 
 def test_hard_server_error():
@@ -50,7 +50,6 @@ def test_hard_server_error():
     assert not mc.set('foo', 1)  # still fail
     time.sleep(RETRY_TIMEOUT + 1)
     assert mc.set('foo', 1)  # back to live
-    memcached_server_ctl('stop', normal_port)
 
 
 def main():

--- a/tests/shabby/run_test.sh
+++ b/tests/shabby/run_test.sh
@@ -2,7 +2,7 @@
 set -e
 BASEDIR=`dirname $0`
 
-python  -c 'import greenify'
+python  -c 'import greenify; import gevent;'
 python $BASEDIR/slow_memcached_server.py > /dev/null &
 pid=$!
 
@@ -27,4 +27,8 @@ echo
 echo "=== test timeout ==="
 echo
 python $BASEDIR/timeout_issue.py
-kill $pid
+echo
+echo "=== test reconnect delay ==="
+echo
+python $BASEDIR/reconnect_delay.py
+kill $pid || exit 0


### PR DESCRIPTION
在rivendb重启期间，rivendb前置proxy经常返回 `SERVER_ERROR wait for retry`，一般重连就好了。如果和物理原因的server不可用的情况一样对待静默5秒，5秒内的操作都会由client端直接报错，会误伤其他请求，不应该这样做。


* * *

https://github.com/memcached/memcached/blob/master/doc/protocol.txt :

```
- "SERVER_ERROR <error>\r\n"

  means some sort of server error prevents the server from carrying
  out the command. <error> is a human-readable error string. In cases
  of severe server errors, which make it impossible to continue
  serving the client (this shouldn't normally happen), the server will
  close the connection after sending the error line. This is the only
  case in which the server closes a connection to a client.
```

cc @youngsofun @zzl0 @tclh123 