### PR TITLE
Connection: Timeout config should be independent between client instances

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -41,6 +41,8 @@
 #define MC_MSG_MORE MSG_MORE
 #endif
 
+
+#define MIN_DATABLOCK_CAPACITY 8192
 #define MC_BUFFER_SIZE 8192
 #define RECV_BUFFER_SIZE 8192
 #define MIN(A, B) (((A) > (B)) ? (B) : (A))

--- a/include/Connection.h
+++ b/include/Connection.h
@@ -26,7 +26,7 @@ class Connection {
     void close();
     const bool alive();
     bool tryReconnect();
-    void markDead(const char* reason, int delay);
+    void markDead(const char* reason, int delay = 0);
     int socketFd() const;
 
     const char* name();
@@ -51,9 +51,9 @@ class Connection {
 
 
     void reset();
-    static void setRetryTimeout(int timeout);
-    static const int getRetryTimeout();
-    static void setConnectTimeout(int timeout);
+    void setRetryTimeout(int timeout);
+    const int getRetryTimeout();
+    void setConnectTimeout(int timeout);
 
     size_t m_counter;
 
@@ -72,8 +72,8 @@ class Connection {
     io::BufferReader* m_buffer_reader; // for recv
     PacketParser m_parser;
 
-    static int s_retryTimeout;
-    static int s_connectTimeout;
+    int m_connectTimeout;
+    int m_retryTimeout;
 
  private:
     Connection(const Connection& conn);
@@ -104,7 +104,7 @@ inline const uint32_t Connection::weight() {
 
 
 inline const int Connection::getRetryTimeout() {
-  return s_retryTimeout;
+  return m_retryTimeout;
 }
 
 

--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -41,11 +41,13 @@ class ConnectionPool {
   void collectBroadcastResult(std::vector<types::broadcast_result_t>& results);
   void collectUnsignedResult(std::vector<types::unsigned_result_t*>& results);
   void reset();
-  static void setPollTimeout(int timeout);
+  void setPollTimeout(int timeout);
+  void setConnectTimeout(int timeout);
+  void setRetryTimeout(int timeout);
 
  protected:
-  void markDeadAll(pollfd_t* pollfds, const char*, int delay);
-  void markDeadConn(Connection* conn, const char* reason, pollfd_t* fd_ptr, int delay);
+  void markDeadAll(pollfd_t* pollfds, const char*);
+  void markDeadConn(Connection* conn, const char* reason, pollfd_t* fd_ptr);
 
   uint32_t m_nActiveConn; // wait for poll
   uint32_t m_nInvalidKey;
@@ -53,7 +55,7 @@ class ConnectionPool {
   hashkit::KetamaSelector m_connSelector;
   Connection *m_conns;
   size_t m_nConns;
-  static int s_pollTimeout;
+  int m_pollTimeout;
 };
 
 } // namespace mc

--- a/include/DataBlock.h
+++ b/include/DataBlock.h
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include "Common.h"
 
-#define MIN_DATABLOCK_CAPACITY 8192
 
 namespace douban {
 namespace mc {
@@ -51,7 +50,7 @@ class DataBlock {
   size_t m_capacity;
   size_t m_size;
   size_t m_nBytesRef;
-  static size_t s_minCapacity;
+  static size_t s_minCapacity;  // FIXME: bad design
 };
 
 

--- a/include/hashkit/ketama.h
+++ b/include/hashkit/ketama.h
@@ -43,11 +43,11 @@ class KetamaSelector {
 
   std::vector<continuum_item_t> m_continuum;
   size_t m_nServers;
-  static size_t s_pointerPerHash;
-  static size_t s_pointerPerServer;
   bool m_useFailover;
   hash_function_t m_hashFunction;
-  static hash_function_t s_defaultHashFunction;
+  static const size_t s_pointerPerHash;
+  static const size_t s_pointerPerServer;
+  static const hash_function_t s_defaultHashFunction;
 
 #ifndef NDEBUG
   bool m_sorted;

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -25,10 +25,10 @@ from ._client import (
 )
 
 __VERSION__ = '0.5.2'
-__version__ = "v0.5.2"
-__author__ = "mckelvin"
-__email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Thu Apr 23 14:47:58 2015 +0800"
+__version__ = "v0.5.2-2-g99cf413"
+__author__ = "zzl"
+__email__ = "zhuzhaolong0@gmail.com"
+__date__ = "Mon May 11 12:15:11 2015 +0800"
 
 
 class Client(PyClient):

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -25,10 +25,10 @@ from ._client import (
 )
 
 __VERSION__ = '0.5.2'
-__version__ = "v0.5.2-2-g99cf413"
-__author__ = "zzl"
-__email__ = "zhuzhaolong0@gmail.com"
-__date__ = "Mon May 11 12:15:11 2015 +0800"
+__version__ = "v0.5.2-4-g53d062a"
+__author__ = "mckelvin"
+__email__ = "mckelvin@users.noreply.github.com"
+__date__ = "Thu May 14 14:34:29 2015 +0800"
 
 
 class Client(PyClient):

--- a/misc/generate_hash_dataset.py
+++ b/misc/generate_hash_dataset.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import zlib
+import binascii
 import hashlib
 import numpy as np
 
@@ -8,7 +8,7 @@ FNV_32_INIT = 0x811c9dc5
 FNV_32_PRIME = 0x01000193
 
 def compute_crc_32(key):
-    return np.uint32(zlib.crc32(key))
+    return np.uint32(binascii.crc32(key))
 
 
 def compute_fnv1_32(key):

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -22,13 +22,13 @@ Client::~Client() {
 void Client::config(config_options_t opt, int val) {
   switch (opt) {
     case CFG_POLL_TIMEOUT:
-      ConnectionPool::setPollTimeout(val);
+      setPollTimeout(val);
       break;
     case CFG_CONNECT_TIMEOUT:
-      Connection::setConnectTimeout(val);
+      setConnectTimeout(val);
       break;
     case CFG_RETRY_TIMEOUT:
-      Connection::setRetryTimeout(val);
+      setRetryTimeout(val);
       break;
     case CFG_HASH_FUNCTION:
       ConnectionPool::setHashFunction(static_cast<douban::mc::hash_function_options_t>(val));

--- a/src/DataBlock.cpp
+++ b/src/DataBlock.cpp
@@ -49,6 +49,7 @@ void DataBlock::init(size_t len) {
 
 
 void DataBlock::setMinCapacity(size_t len) {
+  log_warn("make sure this line is never called in production");
   s_minCapacity = len;
 }
 

--- a/src/hashkit/fnv.cpp
+++ b/src/hashkit/fnv.cpp
@@ -6,10 +6,10 @@ namespace douban {
 namespace mc {
 namespace hashkit {
 
-static uint32_t FNV_32_INIT = 2166136261UL;
+static const uint32_t FNV_32_INIT = 2166136261UL;
 
 #if defined(NO_FNV_GCC_OPTIMIZATION)
-static uint32_t FNV_32_PRIME = 16777619UL;
+static const uint32_t FNV_32_PRIME = 16777619UL;
 #endif
 
 uint32_t hash_fnv1_32(const char *key, size_t key_length) {

--- a/src/hashkit/ketama.cpp
+++ b/src/hashkit/ketama.cpp
@@ -11,9 +11,9 @@ namespace mc {
 namespace hashkit {
 
 
-size_t KetamaSelector::s_pointerPerHash = 1;
-size_t KetamaSelector::s_pointerPerServer = 100;
-hash_function_t KetamaSelector::s_defaultHashFunction = &hash_md5;
+const size_t KetamaSelector::s_pointerPerHash = 1;
+const size_t KetamaSelector::s_pointerPerServer = 100;
+const hash_function_t KetamaSelector::s_defaultHashFunction = &hash_md5;
 
 KetamaSelector::KetamaSelector()
   :m_nServers(0), m_useFailover(false), m_hashFunction(NULL)

--- a/tests/shabby/independent_timeout.py
+++ b/tests/shabby/independent_timeout.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+import libmc
+from slow_memcached_server import PORT, BLOCKING_SECONDS
+
+
+def main():
+    mc1 = libmc.Client(['localhost:%s' % PORT])
+    mc1.config(libmc.MC_POLL_TIMEOUT, BLOCKING_SECONDS * 1000 * 2)
+    assert mc1.version(), "start slow_memcached_server first"
+    mc1.config(libmc.MC_POLL_TIMEOUT, BLOCKING_SECONDS * 1000 / 2)
+    assert not mc1.set('foo', 1)
+    mc2 = libmc.Client(['localhost:%s' % PORT])
+    mc2.config(libmc.MC_POLL_TIMEOUT, BLOCKING_SECONDS * 1000 * 2)
+    assert not mc1.set('foo', 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/shabby/reconnect_delay.py
+++ b/tests/shabby/reconnect_delay.py
@@ -39,14 +39,13 @@ def test_hard_server_error():
     normal_port = 21211
     mc = libmc.Client(["127.0.0.1:%d" % normal_port])
 
-    RETRY_TIMEOUT = 2
+    RETRY_TIMEOUT = 10
     mc.config(libmc.MC_RETRY_TIMEOUT, RETRY_TIMEOUT)
 
     assert mc.set('foo', 1)
     memcached_server_ctl('stop', normal_port)
     assert not mc.set('foo', 1)  # still fail
     memcached_server_ctl('start', normal_port)
-    time.sleep(RETRY_TIMEOUT / 2)
     assert not mc.set('foo', 1)  # still fail
     time.sleep(RETRY_TIMEOUT + 1)
     assert mc.set('foo', 1)  # back to live

--- a/tests/shabby/run_test.sh
+++ b/tests/shabby/run_test.sh
@@ -31,4 +31,9 @@ echo
 echo "=== test reconnect delay ==="
 echo
 python $BASEDIR/reconnect_delay.py
+echo
+echo "=== test independent timeout ==="
+echo
+python $BASEDIR/independent_timeout.py
+
 kill $pid || exit 0

--- a/tests/shabby/slow_memcached_server.py
+++ b/tests/shabby/slow_memcached_server.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+import socket
 import SocketServer
 
 PORT = 0x2305
@@ -117,7 +118,14 @@ class Handler(SocketServer.BaseRequestHandler):
         while True:
             req = ''
             while req[-2:] != '\r\n':
-                req += self.request.recv(8192)
+                try:
+                    req += self.request.recv(8192)
+                except socket.error as ex:
+                    if ex.errno == 54:
+                        pass
+                    else:
+                        raise ex
+
             print '> %s' % req[:-2]
             if not req.strip() or req.strip() == 'quit':
                 break


### PR DESCRIPTION
The issue can be reproduced using `tests/shabby/independent_timeout.py`.

The same timeout **poll timeout** and **connect timeout** were shared by multi client instances in single process, which is not up to expectation.

cc @windreamer @zzl0 