### PR TITLE
Mute logging output of level debug, info, warn

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -68,6 +68,14 @@
 )
 
 void printBacktrace();
+
+#define MC_LOG_LEVEL_ERROR 1
+#define MC_LOG_LEVEL_WARNING 2
+#define MC_LOG_LEVEL_INFO 3
+#define MC_LOG_LEVEL_DEBUG 4
+
+#define MC_LOG_LEVEL MC_LOG_LEVEL_ERROR
+
 #ifdef NDEBUG
 #define debug(M, ...) __VOID_CAST(0)
 
@@ -77,10 +85,15 @@ void printBacktrace();
   __VOID_CAST(0) \
 )
 #else
+
+#if MC_LOG_LEVEL >= MC_LOG_LEVEL_DEBUG
 #define debug(M, ...) ( \
   _mc_output_stderr(DEBUG, "[E: %s] " M, _mc_clean_errno(), ##__VA_ARGS__), \
   __VOID_CAST(0) \
 )
+#else
+#define debug(M, ...) __VOID_CAST(0)
+#endif
 
 #define _ASSERTION_FAILED(cond) ( \
   _mc_output_stderr(PANIC, "failed assertion `%s'" , #cond), \
@@ -88,21 +101,6 @@ void printBacktrace();
   abort() \
 )
 #endif
-
-#define log_info(M, ...) ( \
-  _mc_output_stderr(INFO, M, ##__VA_ARGS__), \
-  __VOID_CAST(0) \
-)
-
-#define log_warn(M, ...) ( \
-  _mc_output_stderr(WARN, "[E: %s] " M, _mc_clean_errno(), ##__VA_ARGS__), \
-  __VOID_CAST(0) \
-)
-
-#define log_err(M, ...) ( \
-  _mc_output_stderr(ERROR, "[E: %s] " M, _mc_clean_errno(), ##__VA_ARGS__), \
-  __VOID_CAST(0) \
-)
 
 #define ASSERT(cond) ( \
   (cond) ? \
@@ -112,6 +110,32 @@ void printBacktrace();
 
 #define NOT_REACHED() ASSERT(0)
 
+#if MC_LOG_LEVEL >= MC_LOG_LEVEL_INFO
+#define log_info(M, ...) ( \
+  _mc_output_stderr(INFO, M, ##__VA_ARGS__), \
+  __VOID_CAST(0) \
+)
+#else
+#define log_info(M, ...) __VOID_CAST(0)
+#endif
+
+#if MC_LOG_LEVEL >= MC_LOG_LEVEL_WARNING
+#define log_warn(M, ...) ( \
+  _mc_output_stderr(WARN, "[E: %s] " M, _mc_clean_errno(), ##__VA_ARGS__), \
+  __VOID_CAST(0) \
+)
+#else
+#define log_warn(M, ...) __VOID_CAST(0)
+#endif
+
+#if MC_LOG_LEVEL >= MC_LOG_LEVEL_ERROR
+#define log_err(M, ...) ( \
+  _mc_output_stderr(ERROR, "[E: %s] " M, _mc_clean_errno(), ##__VA_ARGS__), \
+  __VOID_CAST(0) \
+)
+#else
+#define log_err(M, ...) __VOID_CAST(0)
+#endif
 
 namespace douban {
 namespace mc {

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -25,10 +25,10 @@ from ._client import (
 )
 
 __VERSION__ = '0.5.3'
-__version__ = "v0.5.3"
+__version__ = "v0.5.3-1-g246f020"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Thu May 14 14:34:29 2015 +0800"
+__date__ = "Tue Jul 7 14:21:08 2015 +0800"
 
 
 class Client(PyClient):

--- a/tests/profile_client.cpp
+++ b/tests/profile_client.cpp
@@ -131,6 +131,8 @@ int main() {
   double t0 = getCPUTime(); \
   (REPR); \
   double t1 = getCPUTime(); \
+  (void) t0; \
+  (void) t1; \
   log_info(#REPR" in %.3f s", t1 - t0); \
 } while (0)
 


### PR DESCRIPTION
Sometime a connection may be broken temporally, and it is still in our expectation. Since libmc is stable now, I'm going to decrease verbosity. cc @verycb

```
[xx1] [libmc] [INFO] [src/Connection.cpp:174] Connection xxx12:11211 is back to live at 1435816085
[xx1] [libmc] [INFO] [src/Connection.cpp:174] Connection xxx6:11211 is back to live at 1435816085
```

@zzl0 @youngsofun Please review.