### PR TITLE
Support quit command

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -45,6 +45,7 @@ class Client : public ConnectionPool {
   void destroyBroadcastResult();
 
   err_code_t version(types::broadcast_result_t** results, size_t* nHosts);
+  err_code_t quit();
   err_code_t stats(types::broadcast_result_t** results, size_t* nHosts);
 
   // touch

--- a/include/Keywords.h
+++ b/include/Keywords.h
@@ -32,6 +32,8 @@ static const char k_NOREPLY[] = " noreply";
 static const char kVERSION[] = "version";
 static const char kSTATS[] = "stats";
 
+static const char kQUIT[] = "quit";
+
 
 // error messages for humman
 static const char kSEND_ERROR[] = "send_error";

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -25,10 +25,10 @@ from ._client import (
 )
 
 __VERSION__ = '0.5.3'
-__version__ = "v0.5.3-1-g246f020"
+__version__ = "v0.5.3-3-g3eb1a97"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Tue Jul 7 14:21:08 2015 +0800"
+__date__ = "Sat Jul 11 14:24:54 2015 +0800"
 
 
 class Client(PyClient):

--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -108,60 +108,85 @@ cdef extern from "Client.h" namespace "douban::mc":
         char* getServerAddressByKey(const char* key, size_t keyLen) nogil
         void enableConsistentFailover() nogil
         void disableConsistentFailover() nogil
-        int get(const char* const* keys, const size_t* keyLens, size_t nKeys,
-                retrieval_result_t*** results, size_t* nResults) nogil
-        int gets(const char* const* keys, const size_t* keyLens, size_t nKeys,
-                retrieval_result_t*** results, size_t* nResults) nogil
+        err_code_t get(
+            const char* const* keys, const size_t* keyLens, size_t nKeys,
+            retrieval_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t gets(
+            const char* const* keys, const size_t* keyLens, size_t nKeys,
+            retrieval_result_t*** results, size_t* nResults
+        ) nogil
         void destroyRetrievalResult() nogil
 
-        int set(const char* const* keys, const size_t* key_lens,
-                const flags_t* flags, const exptime_t exptime,
-                const cas_unique_t* cas_uniques, const bool_t noreply,
-                const char* const* vals, const size_t* val_lens,
-                size_t n_items, message_result_t*** results, size_t* nResults) nogil
-        int add(const char* const* keys, const size_t* key_lens,
-                const flags_t* flags, const exptime_t exptime,
-                const cas_unique_t* cas_uniques, const bool_t noreply,
-                const char* const* vals, const size_t* val_lens,
-                size_t n_items, message_result_t*** results, size_t* nResults) nogil
-        int replace(const char* const* keys, const size_t* key_lens,
-                const flags_t* flags, const exptime_t exptime,
-                const cas_unique_t* cas_uniques, const bool_t noreply,
-                const char* const* vals, const size_t* val_lens,
-                size_t n_items, message_result_t*** results, size_t* nResults) nogil
-        int prepend(const char* const* keys, const size_t* key_lens,
-                const flags_t* flags, const exptime_t exptime,
-                const cas_unique_t* cas_uniques, const bool_t noreply,
-                const char* const* vals, const size_t* val_lens,
-                size_t n_items, message_result_t*** results, size_t* nResults) nogil
-        int append(const char* const* keys, const size_t* key_lens,
-                const flags_t* flags, const exptime_t exptime,
-                const cas_unique_t* cas_uniques, const bool_t noreply,
-                const char* const* vals, const size_t* val_lens,
-                size_t n_items, message_result_t*** results, size_t* nResults) nogil
-        int cas(const char* const* keys, const size_t* key_lens,
-                const flags_t* flags, const exptime_t exptime,
-                const cas_unique_t* cas_uniques, const bool_t noreply,
-                const char* const* vals, const size_t* val_lens,
-                size_t n_items, message_result_t*** results, size_t* nResults) nogil
-        int _delete(const char* const* keys, const size_t* key_lens,
-                const bool_t noreply, size_t n_items,
-                message_result_t*** results, size_t* nResults) nogil
-        int touch(const char* const* keys, const size_t* keyLens,
-                const exptime_t exptime, const bool_t noreply, size_t nItems,
-                message_result_t*** results, size_t* nResults) nogil
+        err_code_t set(
+            const char* const* keys, const size_t* key_lens,
+            const flags_t* flags, const exptime_t exptime,
+            const cas_unique_t* cas_uniques, const bool_t noreply,
+            const char* const* vals, const size_t* val_lens,
+            size_t n_items, message_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t add(
+            const char* const* keys, const size_t* key_lens,
+            const flags_t* flags, const exptime_t exptime,
+            const cas_unique_t* cas_uniques, const bool_t noreply,
+            const char* const* vals, const size_t* val_lens,
+            size_t n_items, message_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t replace(
+            const char* const* keys, const size_t* key_lens,
+            const flags_t* flags, const exptime_t exptime,
+            const cas_unique_t* cas_uniques, const bool_t noreply,
+            const char* const* vals, const size_t* val_lens,
+            size_t n_items, message_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t prepend(
+            const char* const* keys, const size_t* key_lens,
+            const flags_t* flags, const exptime_t exptime,
+            const cas_unique_t* cas_uniques, const bool_t noreply,
+            const char* const* vals, const size_t* val_lens,
+            size_t n_items, message_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t append(
+            const char* const* keys, const size_t* key_lens,
+            const flags_t* flags, const exptime_t exptime,
+            const cas_unique_t* cas_uniques, const bool_t noreply,
+            const char* const* vals, const size_t* val_lens,
+            size_t n_items, message_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t cas(
+            const char* const* keys, const size_t* key_lens,
+            const flags_t* flags, const exptime_t exptime,
+            const cas_unique_t* cas_uniques, const bool_t noreply,
+            const char* const* vals, const size_t* val_lens,
+            size_t n_items, message_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t _delete(
+            const char* const* keys, const size_t* key_lens,
+            const bool_t noreply, size_t n_items,
+            message_result_t*** results, size_t* nResults
+        ) nogil
+        err_code_t touch(
+            const char* const* keys, const size_t* keyLens,
+            const exptime_t exptime, const bool_t noreply, size_t nItems,
+            message_result_t*** results, size_t* nResults
+        ) nogil
         void destroyMessageResult() nogil
 
-        int version(broadcast_result_t** results, size_t* nHosts) nogil
-        int stats(broadcast_result_t** results, size_t* nHosts) nogil
+        err_code_t version(broadcast_result_t** results, size_t* nHosts) nogil
+        err_code_t quit() nogil
+        err_code_t stats(broadcast_result_t** results, size_t* nHosts) nogil
         void destroyBroadcastResult() nogil
 
-        int incr(const char* key, const size_t keyLen, const uint64_t delta,
-                 const bool_t noreply, unsigned_result_t*** results,
-                 size_t* nResults) nogil
-        int decr(const char* key, const size_t keyLen, const uint64_t delta,
-                 const bool_t noreply, unsigned_result_t*** results,
-                 size_t* nResults) nogil
+        err_code_t incr(
+            const char* key, const size_t keyLen, const uint64_t delta,
+            const bool_t noreply, unsigned_result_t*** results,
+            size_t* nResults
+        ) nogil
+        err_code_t decr(
+            const char* key, const size_t keyLen, const uint64_t delta,
+            const bool_t noreply, unsigned_result_t*** results,
+            size_t* nResults
+        ) nogil
         void destroyUnsignedResult() nogil
         void _sleep(uint32_t ms) nogil
 
@@ -865,6 +890,15 @@ cdef class PyClient:
         with nogil:
             self._imp.destroyBroadcastResult()
         return rv
+
+    def quit(self):
+        self._record_thread_ident()
+        with nogil:
+            self.last_error = self._imp.quit()
+            self._imp.destroyBroadcastResult()
+        if self.last_error in {RET_CONN_POLL_ERR, RET_RECV_ERR}:
+            return True
+        return False
 
     def stats(self):
         self._record_thread_ident()

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -150,6 +150,13 @@ err_code_t Client::version(types::broadcast_result_t** results, size_t* nHosts) 
 }
 
 
+err_code_t Client::quit() {
+  broadcastCommand(keywords::kQUIT, 4);
+  err_code_t rv = waitPoll();
+  return rv;
+}
+
+
 err_code_t Client::stats(types::broadcast_result_t** results, size_t* nHosts) {
   broadcastCommand(keywords::kSTATS, 5);
   err_code_t rv = waitPoll();

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -150,19 +150,17 @@ void PacketParser::process_packets(err_code_t& err) {
       case FSM_GET_BYTES_CAS: // got "bytes\r" or "bytes cas\r"
         {
           assert(mt_kvPtr != NULL);
-          if (m_state == FSM_GET_BYTES_CAS) {
-            const char c = m_buffer_reader->peek(err, 0);
-            if (err != RET_OK) {
-              return;
-            }
-            if (c == '\n') {  // get
-              mt_kvPtr->cas_unique = 0;
-            } else {  // gets
-              READ_UNSIGNED(mt_kvPtr->cas_unique);
-              SKIP_BYTES(1); // '\r' after cas
-            }
-            m_state = FSM_GET_VALUE_REMAINING;
+          const char c = m_buffer_reader->peek(err, 0);
+          if (err != RET_OK) {
+            return;
           }
+          if (c == '\n') {  // get
+            mt_kvPtr->cas_unique = 0;
+          } else {  // gets
+            READ_UNSIGNED(mt_kvPtr->cas_unique);
+            SKIP_BYTES(1); // '\r' after cas
+          }
+          m_state = FSM_GET_VALUE_REMAINING;
         }
         break;
       case FSM_GET_VALUE_REMAINING: // not got "\n" + all bytes + "\r\n"


### PR DESCRIPTION
- quit: Call `quit()` to close all TCP connections of a client.

@zzl0 Please review.