### PR TITLE
Support server alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,18 @@ set(CMAKE_CXX_FLAGS_COMMON "-Wall -fno-rtti -fno-exceptions")
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG -g2 ${CMAKE_CXX_FLAGS_COMMON}" CACHE STRING "CXX DEBUG FLAGS" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 ${CMAKE_CXX_FLAGS_COMMON}" CACHE STRING "CXX RELEASE FLAGS" FORCE)
 
-FILE(GLOB mc_HEADERS include/*.h include/hashkit/*.h include/llvm/*.h)
-FILE(GLOB mc_SOURCES src/*.cpp src/hashkit/*.cpp)
+FILE(
+    GLOB mc_HEADERS
+    include/*.h
+    include/hashkit/*.h
+    include/llvm/*.h
+    include/rapidjson/*.h
+)
+FILE(
+    GLOB mc_SOURCES
+    src/*.cpp
+    src/hashkit/*.cpp
+)
 
 include_directories(include)
 

--- a/README.rst
+++ b/README.rst
@@ -56,15 +56,34 @@ Configuration
     )
 
     mc = libmc.Client(
-        ['localhost:11211', 'localhost:11212'], do_split=True,
-        comp_threshold=0, noreply=False, prefix=None,
-        hash_fn=MC_HASH_MD5, failover=False
+        [
+        'localhost:11211',
+        'localhost:11212',
+        'remote_host',
+        'remote_host mc.mike',
+        'remote_host:11213 mc.oscar'
+        ],
+        do_split=True,
+        comp_threshold=0,
+        noreply=False,
+        prefix=None,
+        hash_fn=MC_HASH_MD5,
+        failover=False
     )
 
     mc.config(MC_POLL_TIMEOUT, 100)  # 100 ms
     mc.config(MC_CONNECT_TIMEOUT, 300)  # 300 ms
     mc.config(MC_RETRY_TIMEOUT, 5)  # 5 s
 
+
+-  ``servers``: is a list of memcached server addresses. Each address
+   can be in format of ``hostname[:port] [alias]``. ``port`` and ``alias``
+   are optional. If ``port`` is not given, default port ``11211`` will
+   be used. ``alias`` will be used to compute server hash if given,
+   otherwise server hash will be computed based on ``host`` and ``port``
+   (i.e.: If ``port`` is not given or it is equal to ``11211``, ``host`` will be
+   used to compute server hash. If ``port`` is not equal to ``11211``,
+   ``host:port`` will be used).
 -  ``do_split``: Memcached server will refuse to store value if size >=
    1MB, if ``do_split`` is enabled, large value (< 10 MB) will be
    splitted into several blocks. If the value is too large (>= 10 MB),

--- a/include/Connection.h
+++ b/include/Connection.h
@@ -21,7 +21,7 @@ class Connection {
  public:
     Connection();
     ~Connection();
-    int init(const char* host, uint32_t port, uint32_t weight = 0);
+    int init(const char* host, uint32_t port, const char* alias = NULL);
     int connect();
     void close();
     const bool alive();
@@ -32,7 +32,7 @@ class Connection {
     const char* name();
     const char* host();
     const uint32_t port();
-    const uint32_t weight();
+    const bool hasAlias();
 
     void takeBuffer(const char* const buf, size_t buf_len);
     void addRequestKey(const char* const key, const size_t len);
@@ -63,10 +63,10 @@ class Connection {
     char m_name[MC_NI_MAXHOST + 1 + MC_NI_MAXSERV];
     char m_host[MC_NI_MAXHOST];
     uint32_t m_port;
-    uint32_t m_weight; // default 0: without weight
 
     int m_socketFd;
     bool m_alive;
+    bool m_hasAlias;
     time_t m_deadUntil;
     io::BufferWriter* m_buffer_writer; // for send
     io::BufferReader* m_buffer_reader; // for recv
@@ -84,7 +84,6 @@ inline const bool Connection::alive() {
   return m_alive;
 }
 
-
 inline const char* Connection::name() {
   return m_name;
 }
@@ -97,11 +96,9 @@ inline const uint32_t Connection::port() {
   return m_port;
 }
 
-
-inline const uint32_t Connection::weight() {
-  return m_weight;
+inline const bool Connection::hasAlias() {
+  return m_hasAlias;
 }
-
 
 inline const int Connection::getRetryTimeout() {
   return m_retryTimeout;

--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -14,7 +14,7 @@ class ConnectionPool {
   ~ConnectionPool();
   void setHashFunction(hash_function_options_t fn_opt);
   int init(const char* const * hosts, const uint32_t* ports, const size_t n,
-           const uint32_t* weights = NULL);
+           const char* const * aliases = NULL);
   const char* getServerAddressByKey(const char* key, size_t keyLen);
   void enableConsistentFailover();
   void disableConsistentFailover();

--- a/include/hashkit/ketama.h
+++ b/include/hashkit/ketama.h
@@ -13,7 +13,7 @@ namespace hashkit {
 
 typedef struct  continuum_item_s {
   uint32_t hash_value;
-  size_t pool_idx;
+  size_t conn_idx;
   douban::mc::Connection* conn;
 
   static struct compare_s {

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -27,7 +27,7 @@ from ._client import (
 )
 
 __VERSION__ = "0.5.4"
-__version__ = "v0.5.4-5-g4ad1a44"
+__version__ = "v0.5.4-5-g8a969de"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
 __date__ = "Tue Aug 11 14:44:19 2015 +0800"

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -27,10 +27,10 @@ from ._client import (
 )
 
 __VERSION__ = "0.5.4"
-__version__ = "v0.5.4-2-g06b27e8"
-__author__ = "zzl"
-__email__ = "zhuzhaolong0@gmail.com"
-__date__ = "Mon Aug 3 15:03:39 2015 +0800"
+__version__ = "v0.5.4-5-g4ad1a44"
+__author__ = "mckelvin"
+__email__ = "mckelvin@users.noreply.github.com"
+__date__ = "Tue Aug 11 14:44:19 2015 +0800"
 
 
 class Client(PyClient):

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -15,12 +15,12 @@
 using douban::mc::io::BufferWriter;
 using douban::mc::io::BufferReader;
 
-namespace douban{
+namespace douban {
 namespace mc {
 
 Connection::Connection()
-    : m_counter(0), m_port(0), m_weight(0) , m_socketFd(-1),
-      m_alive(false), m_deadUntil(0),
+    : m_counter(0), m_port(0), m_socketFd(-1),
+      m_alive(false), m_hasAlias(false), m_deadUntil(0),
       m_connectTimeout(MC_DEFAULT_CONNECT_TIMEOUT),
       m_retryTimeout(MC_DEFAULT_RETRY_TIMEOUT) {
   m_name[0] = '\0';
@@ -40,11 +40,16 @@ Connection::~Connection() {
   delete m_buffer_reader;
 }
 
-int Connection::init(const char* host, uint32_t port, uint32_t weight) {
+int Connection::init(const char* host, uint32_t port, const char* alias) {
   snprintf(m_host, sizeof m_host, "%s", host);
   m_port = port;
-  snprintf(m_name, sizeof m_name, "%s:%u", m_host, m_port);
-  m_weight = weight;
+  if (alias == NULL) {
+    m_hasAlias = false;
+    snprintf(m_name, sizeof m_name, "%s:%u", m_host, m_port);
+  } else {
+    m_hasAlias = true;
+    snprintf(m_name, sizeof m_name, "%s", alias);
+  }
   return -1; // -1 means the connection is not established yet
 }
 

--- a/src/ConnectionPool.cpp
+++ b/src/ConnectionPool.cpp
@@ -58,14 +58,14 @@ void ConnectionPool::setHashFunction(hash_function_options_t fn_opt) {
 
 
 int ConnectionPool::init(const char* const * hosts, const uint32_t* ports, const size_t n,
-                         const uint32_t* weights) {
+                         const char* const * aliases) {
   delete[] m_conns;
   m_connSelector.reset();
   int rv = 0;
   m_nConns = n;
   m_conns = new Connection[m_nConns];
   for (size_t i = 0; i < m_nConns; i++) {
-    rv += m_conns[i].init(hosts[i], ports[i]);
+    rv += m_conns[i].init(hosts[i], ports[i], aliases == NULL ? NULL : aliases[i]);
   }
   m_connSelector.addServers(m_conns, m_nConns);
   return rv;

--- a/tests/shabby/gevent_issue.py
+++ b/tests/shabby/gevent_issue.py
@@ -20,7 +20,11 @@ stack = []
 def mc_sleep():
     print 'begin mc sleep'
     stack.append('mc_sleep_begin')
-    assert mc.set('foo', 'bar'), "Run `python slow_memcached_server.py` first"
+    for i in range(3):
+        if mc.set('foo', 'bar'):
+            break
+    else:
+        raise Exception("Run `python slow_memcached_server.py` first")
     stack.append('mc_sleep_end')
     print 'end mc sleep'
 

--- a/tests/test_cmemcached_regression.py
+++ b/tests/test_cmemcached_regression.py
@@ -470,11 +470,53 @@ class CmemcachedRegressionPrefixCase(unittest.TestCase):
         for k in rs:
             self.assertEqual(mc.get_host_by_key(k), rs[k])
 
+    def test_ketama_with_jocky_alias(self):
+        mc = Client([
+            'localhost localhost',
+            'myhost:11211 myhost',
+            '127.0.0.1:11212 127.0.0.1:11212',
+            'myhost:11213 myhost:11213'
+        ])
+        rs = {
+            'test:10000': 'localhost',
+            'test:20000': '127.0.0.1:11212',
+            'test:30000': '127.0.0.1:11212',
+            'test:40000': '127.0.0.1:11212',
+            'test:50000': '127.0.0.1:11212',
+            'test:60000': 'myhost:11213',
+            'test:70000': '127.0.0.1:11212',
+            'test:80000': '127.0.0.1:11212',
+            'test:90000': '127.0.0.1:11212',
+        }
+        for k in rs:
+            self.assertEqual(mc.get_host_by_key(k), rs[k])
+
+    def test_ketama_with_alias(self):
+        mc = Client([
+            '192.168.1.211:11211 tango.mc.douban.com',
+            '192.168.1.212:11212 uniform.mc.douban.com',
+            '192.168.1.211:11212 victor.mc.douban.com',
+            '192.168.1.212:11211 whiskey.mc.douban.com',
+        ])
+        rs = {
+            'test:10000': 'whiskey.mc.douban.com',
+            'test:20000': 'victor.mc.douban.com',
+            'test:30000': 'victor.mc.douban.com',
+            'test:40000': 'victor.mc.douban.com',
+            'test:50000': 'victor.mc.douban.com',
+            'test:60000': 'uniform.mc.douban.com',
+            'test:70000': 'tango.mc.douban.com',
+            'test:80000': 'victor.mc.douban.com',
+            'test:90000': 'victor.mc.douban.com',
+        }
+        for k in rs:
+            self.assertEqual(mc.get_host_by_key(k), rs[k])
+
     def test_prefixed_ketama(self):
         mc = Client(
             ['localhost', 'myhost:11211', '127.0.0.1:11212', 'myhost:11213'],
             prefix="/prefix"
-            )
+        )
         rs = {
             'test:10000': '127.0.0.1:11212',
             'test:20000': 'localhost:11211',

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -51,9 +51,31 @@ mc::Client* newClient(int n) {
     21211, 21212, 21213, 21214, 21215, 21216, 21217, 21218, 21219, 21220,
     21221, 21222, 21223, 21224, 21225, 21226, 21227, 21228, 21229, 21230
   };
+  const char * aliases[] = {
+    "alfa",
+    "bravo",
+    "charlie",
+    "delta",
+    "echo",
+    NULL,
+    "golf",
+    "hotel",
+    "india",
+    "juliett",
+    "kilo",
+    "lima",
+    "mike",
+    "november",
+    "oscar",
+    "papa",
+    "quebec",
+    "romeo",
+    "sierra",
+    "tango"
+  };
   mc::Client* client = new mc::Client();
   client->config(mc::CFG_HASH_FUNCTION, mc::OPT_HASH_MD5);
-  client->init(hosts, ports, n);
+  client->init(hosts, ports, n, aliases);
   types::broadcast_result_t* results;
   size_t nHosts;
   int ret = client->version(&results, &nHosts);


### PR DESCRIPTION
Now it's possible to migrate from `mc-server1:11211` to `mc-server2:11212` (when both host and port are changed) without changing the hash ring.

cc @zzl0 