### PR TITLE
Expose libmc.decode_value

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -2,6 +2,7 @@ import os
 from ._client import (
     PyClient, ThreadUnsafe,
     encode_value,
+    decode_value,
 
     MC_DEFAULT_EXPTIME,
     MC_POLL_TIMEOUT,
@@ -27,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "0.5.4"
-__version__ = "v0.5.4-5-g8a969de"
-__author__ = "mckelvin"
+__version__ = "v0.5.4-7-g467dcd9"
+__author__ = "PAN, Myautsai"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Tue Aug 11 14:44:19 2015 +0800"
+__date__ = "Thu Aug 13 14:26:19 2015 +0800"
 
 
 class Client(PyClient):
@@ -41,7 +42,7 @@ DYNAMIC_LIBRARIES = [os.path.abspath(_libmc_so_file)]
 
 
 __all__ = [
-    'Client', 'ThreadUnsafe', '__VERSION__', 'encode_value',
+    'Client', 'ThreadUnsafe', '__VERSION__', 'encode_value', 'decode_value',
 
     'MC_DEFAULT_EXPTIME', 'MC_POLL_TIMEOUT', 'MC_CONNECT_TIMEOUT',
     'MC_RETRY_TIMEOUT',

--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -282,11 +282,11 @@ cdef bytes _encode_value(object val, int comp_threshold, flags_t *flags):
 
 def encode_value(object val, int comp_threshold):
     cdef flags_t flags
-    cdef bytes = _encode_value(val, comp_threshold, &flags)
-    return bytes, flags
+    cdef bytes buf = _encode_value(val, comp_threshold, &flags)
+    return buf, flags
 
 
-cdef object _decode_value(bytes val, flags_t flags):
+cpdef object decode_value(bytes val, flags_t flags):
     cdef object dec_val = None
     if flags & _FLAG_COMPRESS:
         try:
@@ -482,7 +482,7 @@ cdef class PyClient:
         if py_value is None:
             return
 
-        return _decode_value(py_value, flags)
+        return decode_value(py_value, flags)
 
     def gets(self, basestring key):
         self._record_thread_ident()
@@ -500,7 +500,7 @@ cdef class PyClient:
         if py_value is None:
             return
 
-        return _decode_value(py_value, flags), cas_unique
+        return decode_value(py_value, flags), cas_unique
 
     def _get_multi_raw(self, size_t n, list keys):
         cdef size_t n_res = 0
@@ -551,7 +551,7 @@ cdef class PyClient:
                 raw_bytes, flags  = self._get_large_raw(keys[i], n_splits, flags)
             if raw_bytes is None:
                 continue
-            dct[out_key] = _decode_value(raw_bytes, flags)
+            dct[out_key] = decode_value(raw_bytes, flags)
 
         return dct
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,8 @@
 import sys
 import unittest
 from libmc import (
-    Client, encode_value, MC_RETURN_OK, MC_RETURN_INVALID_KEY_ERR,
+    Client, encode_value, decode_value,
+    MC_RETURN_OK, MC_RETURN_INVALID_KEY_ERR,
     MC_RETURN_MC_SERVER_ERR
 )
 
@@ -11,6 +12,15 @@ from libmc import (
 # defined in _client.pyx
 _FLAG_DOUBAN_CHUNKED = 1 << 12
 _DOUBAN_CHUNK_SIZE = 1000000
+
+
+class DiveMaster(object):
+
+    def __init__(self, id_):
+        self.id = id_
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and other.id == self.id
 
 
 class MiscCase(unittest.TestCase):
@@ -22,6 +32,22 @@ class MiscCase(unittest.TestCase):
         vi = sys.version_info
         if vi.major == 2 and vi.micro == 7 and vi.minor < 9:
             assert encode_value(('douban', 0), 0) == expect
+
+    def test_decode_value(self):
+        dataset = [
+            True,
+            0,
+            100,
+            1000L,
+            10.24,
+            DiveMaster(1024),
+            "scubadiving",
+        ]
+        for d in dataset:
+            new_d = decode_value(*encode_value(d, 0))
+            assert new_d == d
+            if isinstance(d, DiveMaster):
+              assert d is not new_d
 
 
 class SingleServerCase(unittest.TestCase):


### PR DESCRIPTION
`encode_value` and `decode_value` will be used for serialization in localcache.

cc @zzl0 