### PR TITLE
golibmc: Return better errors; Add benchmark script

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -35,16 +35,14 @@
 #define MC_NI_MAXSERV 32
 #endif
 
-#ifndef MSG_MORE
-#define MC_MSG_MORE 0
-#else
+#ifdef MSG_MORE
 #define MC_MSG_MORE MSG_MORE
+#else
+#define MC_MSG_MORE 0
 #endif
 
 
 #define MIN_DATABLOCK_CAPACITY 8192
-#define MC_BUFFER_SIZE 8192
-#define RECV_BUFFER_SIZE 8192
 #define MIN(A, B) (((A) > (B)) ? (B) : (A))
 #define MAX(A, B) (((A) < (B)) ? (B) : (A))
 #define CSTR(STR) (const_cast<char*>(STR))

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "0.5.6"
-__version__ = "v0.5.6-1-g4edef04"
+__version__ = "v0.5.6-2-g7a965e8"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Tue Nov 3 19:24:44 2015 +0800"
+__date__ = "Wed Nov 4 15:41:18 2015 +0800"
 
 
 class Client(PyClient):

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "0.5.6"
-__version__ = "v0.5.6"
-__author__ = "PAN, Myautsai"
+__version__ = "v0.5.6-1-g4edef04"
+__author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Tue Nov 3 16:49:31 2015 +0800"
+__date__ = "Tue Nov 3 19:24:44 2015 +0800"
 
 
 class Client(PyClient):

--- a/misc/gomcbench/README.md
+++ b/misc/gomcbench/README.md
@@ -1,0 +1,38 @@
+# Benchmark for golibmc
+
+(compared with [bradfitz/gomemcache](https://github.com/bradfitz/gomemcache/))
+
+## How to run the benchmark
+
+    go get github.com/bradfitz/gomemcache/memcache
+    go get github.com/douban/libmc/golibmc
+    cd misc/gomcbench
+    go test -bench .
+
+## Results
+
+result based on a MacBook Pro (Retina, 13-inch, Late 2013) w/ 8GB Mem, and a 2.4 GHz Intel Core i5 CPU.
+
+    BenchmarkGolibmcGetSingleSmallValue-4   	   30000	     46638 ns/op
+    BenchmarkGomemcacheGetSingleSmallValue-4	   20000	     87720 ns/op
+
+    BenchmarkGolibmcGetSingleLargeValue-4   	   20000	     83470 ns/op
+    BenchmarkGomemcacheGetSingleLargeValue-4	   10000	    110609 ns/op
+
+    BenchmarkGolibmcGet10SmallValues-4      	   10000	    137134 ns/op
+    BenchmarkGomemcacheGet10SmallValues-4   	    5000	    329235 ns/op
+
+    BenchmarkGolibmcGet100SmallValues-4     	    3000	    382400 ns/op
+    BenchmarkGomemcacheGet100SmallValues-4  	    2000	    894691 ns/op
+
+    BenchmarkGolibmcGet1000SmallValues-4    	     500	   2212252 ns/op
+    BenchmarkGomemcacheGet1000SmallValues-4 	     200	   6924752 ns/op
+
+    BenchmarkGolibmcGet10LargeValues-4      	    5000	    284501 ns/op
+    BenchmarkGomemcacheGet10LargeValues-4   	    3000	    546686 ns/op
+
+    BenchmarkGolibmcGet100LargeValues-4     	     500	   2892901 ns/op
+    BenchmarkGomemcacheGet100LargeValues-4  	     500	   3534152 ns/op
+
+    BenchmarkGolibmcGet1000LargeValues-4    	      50	  21692412 ns/op
+    BenchmarkGomemcacheGet1000LargeValues-4 	      50	  22605197 ns/op

--- a/misc/gomcbench/gomcbench_test.go
+++ b/misc/gomcbench/gomcbench_test.go
@@ -1,0 +1,176 @@
+package gomcbench
+
+import "fmt"
+import "strings"
+import "testing"
+import "github.com/douban/libmc/golibmc"
+import "github.com/bradfitz/gomemcache/memcache"
+
+const NSERVERS int = 10
+const key1 string = "google"
+
+var smallValue []byte = []byte("google")                   // 6B
+var largeValue []byte = []byte(strings.Repeat("A", 10240)) // 10 KB
+
+func getGolibmcClient(nServers int) *golibmc.Client {
+	servers := make([]string, nServers)
+	for i := 0; i < nServers; i++ {
+		servers[i] = fmt.Sprintf("localhost:%d", 21211+i)
+	}
+	noreply := false
+	prefix := ""
+	hashFunc := golibmc.HashCRC32
+	failover := false
+	disableLock := false
+	return golibmc.New(servers, noreply, prefix, hashFunc, failover, disableLock)
+}
+
+func getGomemcacheClient(nServers int) *memcache.Client {
+	servers := make([]string, nServers)
+	for i := 0; i < nServers; i++ {
+		servers[i] = fmt.Sprintf("localhost:%d", 21211+i)
+	}
+
+	return memcache.New(servers...)
+}
+
+func benchmarkGolibmcGetSingleValue(nTimes int, value []byte) {
+	mc := getGolibmcClient(NSERVERS)
+	item := golibmc.Item{
+		Key:   key1,
+		Value: value,
+	}
+	mc.Set(&item)
+	for i := 0; i < nTimes; i++ {
+		mc.Get(key1)
+	}
+}
+
+func benchmarkGomemcacheGetSingleValue(nTimes int, value []byte) {
+	mc := getGomemcacheClient(NSERVERS)
+	item := memcache.Item{
+		Key:   key1,
+		Value: value,
+	}
+	mc.Set(&item)
+	for i := 0; i < nTimes; i++ {
+		mc.Get(key1)
+	}
+}
+
+func benchmarkGolibmcGetMultiValues(nTimes int, nItems int, value []byte) {
+	mc := getGolibmcClient(NSERVERS)
+	keys := make([]string, nItems)
+	items := make([]*golibmc.Item, nItems)
+	for i := 0; i < nItems; i++ {
+		key := fmt.Sprintf("test_multi_key_%d", i)
+		items[i] = &golibmc.Item{
+			Key:   key,
+			Value: value,
+		}
+		keys[i] = key
+	}
+
+	mc.SetMulti(items)
+	for i := 0; i < nTimes; i++ {
+		mc.GetMulti(keys)
+	}
+}
+
+func benchmarkGomemcacheGetMultiValues(nTimes int, nItems int, value []byte) {
+	mc := getGomemcacheClient(NSERVERS)
+	keys := make([]string, nItems)
+	for i := 0; i < nItems; i++ {
+		key := fmt.Sprintf("test_multi_key_%d", i)
+		item := &memcache.Item{
+			Key:   key,
+			Value: value,
+		}
+		keys[i] = key
+		mc.Set(item)
+	}
+
+	for i := 0; i < nTimes; i++ {
+		mc.GetMulti(keys)
+	}
+}
+
+// get small value
+
+func BenchmarkGolibmcGetSingleSmallValue(b *testing.B) {
+	benchmarkGolibmcGetSingleValue(b.N, smallValue)
+}
+
+func BenchmarkGomemcacheGetSingleSmallValue(b *testing.B) {
+	benchmarkGomemcacheGetSingleValue(b.N, smallValue)
+}
+
+// get large value
+
+func BenchmarkGolibmcGetSingleLargeValue(b *testing.B) {
+	benchmarkGolibmcGetSingleValue(b.N, largeValue)
+}
+
+func BenchmarkGomemcacheGetSingleLargeValue(b *testing.B) {
+	benchmarkGomemcacheGetSingleValue(b.N, largeValue)
+}
+
+// get multi(10) small value
+
+func BenchmarkGolibmcGet10SmallValues(b *testing.B) {
+	benchmarkGolibmcGetMultiValues(b.N, 10, smallValue)
+}
+
+func BenchmarkGomemcacheGet10SmallValues(b *testing.B) {
+	benchmarkGomemcacheGetMultiValues(b.N, 10, smallValue)
+}
+
+// get multi(100) small value
+
+func BenchmarkGolibmcGet100SmallValues(b *testing.B) {
+	benchmarkGolibmcGetMultiValues(b.N, 100, smallValue)
+}
+
+func BenchmarkGomemcacheGet100SmallValues(b *testing.B) {
+	benchmarkGomemcacheGetMultiValues(b.N, 100, smallValue)
+}
+
+// get multi(1000) small value
+
+func BenchmarkGolibmcGet1000SmallValues(b *testing.B) {
+	benchmarkGolibmcGetMultiValues(b.N, 1000, smallValue)
+}
+
+func BenchmarkGomemcacheGet1000SmallValues(b *testing.B) {
+	benchmarkGomemcacheGetMultiValues(b.N, 1000, smallValue)
+}
+
+// get multi(10) large value
+
+func BenchmarkGolibmcGet10LargeValues(b *testing.B) {
+	benchmarkGolibmcGetMultiValues(b.N, 10, largeValue)
+}
+
+func BenchmarkGomemcacheGet10LargeValues(b *testing.B) {
+	benchmarkGomemcacheGetMultiValues(b.N, 10, largeValue)
+}
+
+// get multi(100) large value
+
+func BenchmarkGolibmcGet100LargeValues(b *testing.B) {
+	benchmarkGolibmcGetMultiValues(b.N, 100, largeValue)
+}
+
+func BenchmarkGomemcacheGet100LargeValues(b *testing.B) {
+	benchmarkGomemcacheGetMultiValues(b.N, 100, largeValue)
+}
+
+// get multi(1000) large value
+
+func BenchmarkGolibmcGet1000LargeValues(b *testing.B) {
+	benchmarkGolibmcGetMultiValues(b.N, 1000, largeValue)
+}
+
+func BenchmarkGomemcacheGet1000LargeValues(b *testing.B) {
+	benchmarkGomemcacheGetMultiValues(b.N, 1000, largeValue)
+}

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v0.5.6-1-g4edef04"
+const _Version = "v0.5.6-2-g7a965e8"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Tue Nov 3 19:24:44 2015 +0800"
+const _Date = "Wed Nov 4 15:41:18 2015 +0800"
 
 // Version of the package
 const Version = _Version

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v0.5.6"
-const _Author = "PAN, Myautsai"
+const _Version = "v0.5.6-1-g4edef04"
+const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Tue Nov 3 16:49:31 2015 +0800"
+const _Date = "Tue Nov 3 19:24:44 2015 +0800"
 
 // Version of the package
 const Version = _Version


### PR DESCRIPTION
Incompatible golibmc API changes:

- An error of `ErrMalformedKey` will be returned in any command where the input key or any of the keys is [considered](https://github.com/memcached/memcached/blob/c10feb9/doc/protocol.txt#L41-L49) as an invalid/malformed key.
- `Get` a not-existed-key will return an error of `ErrCacheMiss` instead of `nil`. Similar changes applied to the following commands: `Touch`, `Incr`, `Desc`, `Gets`, `GetMulti`, `Add`, `Replace`, `Cas`, `Delete`, `DeleteMulti` with the following errors: `ErrCacheMiss`, `ErrCASConflict`, `ErrNotStored`.