### PR TITLE
PacketParser::start_state: skipBytes after checking first few bytes

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "0.5.6"
-__version__ = "v0.5.6-2-g7a965e8"
-__author__ = "mckelvin"
+__version__ = "v0.5.6-4-g0112646"
+__author__ = "PAN, Myautsai"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Wed Nov 4 15:41:18 2015 +0800"
+__date__ = "Thu Feb 4 18:35:05 2016 +0800"
 
 
 class Client(PyClient):

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -256,7 +256,7 @@ int PacketParser::start_state(err_code_t& err) {
   }
   // log_info("start_state with %c", c1);
 
-
+#ifndef NDEBUG
 #define EXPECT_BYTES(S, N) \
   do { \
     m_buffer_reader->expectBytes(err, (S), (N)); \
@@ -264,6 +264,15 @@ int PacketParser::start_state(err_code_t& err) {
       return 0; \
     } \
   } while (0)
+#else
+#define EXPECT_BYTES(S, N) \
+  do { \
+    m_buffer_reader->skipBytes(err, (N)); \
+    if (err != RET_OK) { \
+      return 0; \
+    } \
+  } while (0)
+#endif
 
   switch (c1) {
     case 'V':
@@ -433,6 +442,8 @@ int PacketParser::start_state(err_code_t& err) {
       break;
   }
   return 0;
+
+#undef EXPECT_BYTES
 }
 
 

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v0.5.6-2-g7a965e8"
-const _Author = "mckelvin"
+const _Version = "v0.5.6-4-g0112646"
+const _Author = "PAN, Myautsai"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Wed Nov 4 15:41:18 2015 +0800"
+const _Date = "Thu Feb 4 18:35:05 2016 +0800"
 
 // Version of the package
 const Version = _Version


### PR DESCRIPTION
Both the memcached protocol and the libmc software
are stable now.  Code snippets where
`expectBytes` is used are more like assertions.
We don't need to check all of bytes in production
so let's just skip them using `skipBytes`.

@zzl0 Please review.