### PR TITLE
golibmc_test: Fix fragile test case "testQuit"

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.0.0"
-__version__ = "v1.0.0"
-__author__ = "PAN, Myautsai"
+__version__ = "v1.0.0-5-gcd1baf5"
+__author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Thu Mar 24 12:20:00 2016 +0800"
+__date__ = "Thu May 19 11:13:05 2016 +0800"
 
 
 class Client(PyClient):

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.0.0"
-const _Author = "PAN, Myautsai"
+const _Version = "v1.0.0-5-gcd1baf5"
+const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Thu Mar 24 12:20:00 2016 +0800"
+const _Date = "Thu May 19 11:13:05 2016 +0800"
 
 // Version of the package
 const Version = _Version


### PR DESCRIPTION
The bug is not stable to reproduce on Linux and
it CANNOT be reproduced on OS X. A possible explanation to this
phenomenon is:

Sending version command will not increase the `curr_connections` metric,
and only data I/O commands like Set/Get/Delete commands will do. The
idea of this commit is to make sure the current connection to
target memcached server is established and confirmed by the server-end
(curr_connections + 1).

```
--- FAIL: TestQuit (0.01s)
	golibmc_test.go:852: nc1: 10, nc2: 5
```