### PR TITLE
golibmc: Fix heap overflow

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.0.1"
-__version__ = "v1.0.1"
-__author__ = "youngsofun"
-__email__ = "youngsofun@users.noreply.github.com"
-__date__ = "Fri May 20 12:00:00 2016 +0800"
+__version__ = "v1.0.1-1-ga29a5c0"
+__author__ = "mckelvin"
+__email__ = "mckelvin@users.noreply.github.com"
+__date__ = "Tue Jun 28 11:03:35 2016 +0800"
 
 
 class Client(PyClient):

--- a/src/golibmc.go
+++ b/src/golibmc.go
@@ -460,7 +460,7 @@ func (client *Client) SetMulti(items []*Item) (failedKeys []string, err error) {
 
 	sr := unsafe.Sizeof(*results)
 	storedKeySet := make(map[string]struct{})
-	for i := 0; i <= int(n); i++ {
+	for i := 0; i < int(n); i++ {
 		if (*results).type_ == C.MSG_STORED {
 			storedKey := C.GoStringN((*results).key, C.int((*results).key_len))
 			storedKeySet[storedKey] = struct{}{}
@@ -580,7 +580,7 @@ func (client *Client) DeleteMulti(keys []string) (failedKeys []string, err error
 
 	deletedKeySet := make(map[string]struct{})
 	sr := unsafe.Sizeof(*results)
-	for i := 0; i <= int(n); i++ {
+	for i := 0; i < int(n); i++ {
 		if (*results).type_ == C.MSG_DELETED {
 			deletedKey := C.GoStringN((*results).key, C.int((*results).key_len))
 			deletedKeySet[deletedKey] = struct{}{}

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.0.1"
-const _Author = "youngsofun"
-const _Email = "youngsofun@users.noreply.github.com"
-const _Date = "Fri May 20 12:00:00 2016 +0800"
+const _Version = "v1.0.1-1-ga29a5c0"
+const _Author = "mckelvin"
+const _Email = "mckelvin@users.noreply.github.com"
+const _Date = "Tue Jun 28 11:03:35 2016 +0800"
 
 // Version of the package
 const Version = _Version


### PR DESCRIPTION
The bug is introduced (by me 😭 ) in https://github.com/douban/libmc/commit/2be0ce21501e7cbb4201d05d205c895994a25d9d#diff-28d9b0fb9ad32686216c98f74a3c7363R286 and another commit somehow I can't find it:

```diff
-	for i := 0; i <= int(n); i++ {
+	for i := 0; i < int(n); i++ {
```

Where `n` is the size of the result. `i < int(n)` should be used here.

SEE: https://github.com/douban/libmc/issues/42

@mosasiru Would you please try this PR?

cc @youngsofun @mapix