### PR TITLE
fix failover issue

### DIFF
--- a/src/HashkitKetama.cpp
+++ b/src/HashkitKetama.cpp
@@ -128,8 +128,7 @@ std::vector<continuum_item_t>::iterator KetamaSelector::getServerIt(const char* 
         if (it == m_continuum.end()) {
           it = m_continuum.begin();
         }
-        if (it->conn != origin_conn && it->conn->tryReconnect()) {
-          origin_conn = it->conn;
+        if (it->conn->tryReconnect()) {
           break;
         }
       } while (--max_iter);


### PR DESCRIPTION
I try to fix https://github.com/douban/libmc/issues/46 issue.
I'm sorry that I have no confidence. Could you check this?


I think the condition of `it->conn != origin_conn`  is not needed because `origin_nonn` is recoverble, and the first time `origin_conn` is always dead.