### PR TITLE
KetamaSelector: Call conn->tryReconnect before failover (Fix #46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ _client.so
 .clang_complete
 .eggs/
 .tox/
+.cache/
 tests/resources/keys_*.txt

--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -16,6 +16,7 @@ class ConnectionPool {
   int init(const char* const * hosts, const uint32_t* ports, const size_t n,
            const char* const * aliases = NULL);
   const char* getServerAddressByKey(const char* key, size_t keyLen);
+  const char* getRealtimeServerAddressByKey(const char* key, size_t keyLen);
   void enableConsistentFailover();
   void disableConsistentFailover();
   void dispatchRetrieval(op_code_t op, const char* const* keys, const size_t* keyLens,

--- a/include/c_client.h
+++ b/include/c_client.h
@@ -16,6 +16,8 @@ extern "C" {
   void client_destroy(void* client);
 
   const char* client_get_server_address_by_key(void* client, const char* key, size_t key_len);
+  const char* client_get_realtime_server_address_by_key(void* client, const char* key,
+                                                        size_t key_len);
 
   int client_version(void* client, broadcast_result_t** results, size_t* n_hosts);
   void client_destroy_broadcast_result(void* client);

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.0.1"
-__version__ = "v1.0.1-1-ga29a5c0"
-__author__ = "mckelvin"
-__email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Tue Jun 28 11:03:35 2016 +0800"
+__version__ = "v1.0.1-8-g624ca73"
+__author__ = "youngsofun"
+__email__ = "yangxiufeng.c@gmail.com"
+__date__ = "Mon Jul 11 10:58:10 2016 +0800"
 
 
 class Client(PyClient):

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.0.1"
-__version__ = "v1.0.1-10-g6753c61"
+__version__ = "v1.0.1-11-g7b0a034"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Tue Nov 1 00:12:24 2016 +0800"
+__date__ = "Tue Nov 1 00:14:39 2016 +0800"
 
 
 class Client(PyClient):

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.0.1"
-__version__ = "v1.0.1-8-g624ca73"
-__author__ = "youngsofun"
-__email__ = "yangxiufeng.c@gmail.com"
-__date__ = "Mon Jul 11 10:58:10 2016 +0800"
+__version__ = "v1.0.1-10-g6753c61"
+__author__ = "mckelvin"
+__email__ = "mckelvin@users.noreply.github.com"
+__date__ = "Tue Nov 1 00:12:24 2016 +0800"
 
 
 class Client(PyClient):

--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -115,6 +115,7 @@ cdef extern from "Client.h" namespace "douban::mc":
         int init(const char* const * hosts, const uint32_t* ports, size_t n,
                  const char* const * aliases) nogil
         char* getServerAddressByKey(const char* key, size_t keyLen) nogil
+        char* getRealtimeServerAddressByKey(const char* key, size_t keyLen) nogil
         void enableConsistentFailover() nogil
         void disableConsistentFailover() nogil
         err_code_t get(
@@ -429,6 +430,20 @@ cdef class PyClient:
         Py_DECREF(key2)
         return c_server_addr
 
+    def get_realtime_host_by_key(self, basestring key):
+        cdef bytes key2 = self.normalize_key(key)
+        cdef char* c_key = NULL
+        cdef const char* c_addr = NULL
+        cdef size_t c_key_len = 0
+        Py_INCREF(key2)
+        PyString_AsStringAndSize(key2, &c_key, <Py_ssize_t*>&c_key_len)
+        with nogil:
+            c_addr = self._imp.getRealtimeServerAddressByKey(c_key, c_key_len)
+        Py_DECREF(key2)
+        cdef basestring c_server_addr
+        if c_addr != NULL:
+            c_server_addr = c_addr
+            return c_server_addr
 
     cdef normalize_key(self, basestring raw_key):
         cdef bytes key

--- a/src/ConnectionPool.cpp
+++ b/src/ConnectionPool.cpp
@@ -81,6 +81,16 @@ const char* ConnectionPool::getServerAddressByKey(const char* key, size_t keyLen
 }
 
 
+const char* ConnectionPool::getRealtimeServerAddressByKey(const char* key, size_t keyLen) {
+  bool check_alive = true;
+  Connection* conn = m_connSelector.getConn(key, keyLen, check_alive);
+  if (conn == NULL) {
+    return NULL;
+  }
+  return conn->name();
+}
+
+
 void ConnectionPool::enableConsistentFailover() {
   m_connSelector.enableFailover();
 }

--- a/src/HashkitKetama.cpp
+++ b/src/HashkitKetama.cpp
@@ -117,7 +117,7 @@ std::vector<continuum_item_t>::iterator KetamaSelector::getServerIt(const char* 
 
   bool is_alive = true;
   if (check_alive && origin_conn != NULL) {
-     is_alive = origin_conn->alive();
+     is_alive = origin_conn->tryReconnect();
   }
 
   if (!is_alive) {
@@ -138,9 +138,7 @@ std::vector<continuum_item_t>::iterator KetamaSelector::getServerIt(const char* 
         return m_continuum.end();
       }
     } else {
-      if (!it->conn->tryReconnect()) {
-        return m_continuum.end();
-      }
+      return m_continuum.end();
     }
   }
 

--- a/src/HashkitKetama.cpp
+++ b/src/HashkitKetama.cpp
@@ -129,7 +129,6 @@ std::vector<continuum_item_t>::iterator KetamaSelector::getServerIt(const char* 
           it = m_continuum.begin();
         }
         if (it->conn != origin_conn && it->conn->tryReconnect()) {
-          origin_conn = it->conn;
           break;
         }
       } while (--max_iter);

--- a/src/c_client.cpp
+++ b/src/c_client.cpp
@@ -40,6 +40,13 @@ const char* client_get_server_address_by_key(void* client, const char* key, size
 }
 
 
+const char* client_get_realtime_server_address_by_key(void* client, const char* key,
+                                                      size_t key_len) {
+  douban::mc::Client* c = static_cast<Client*>(client);
+  return c->getRealtimeServerAddressByKey(key, key_len);
+}
+
+
 int client_version(void* client, broadcast_result_t** results, size_t* n_hosts) {
   douban::mc::Client* c = static_cast<Client*>(client);
   return c->version(results, n_hosts);

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.0.1-8-g624ca73"
-const _Author = "youngsofun"
-const _Email = "yangxiufeng.c@gmail.com"
-const _Date = "Mon Jul 11 10:58:10 2016 +0800"
+const _Version = "v1.0.1-10-g6753c61"
+const _Author = "mckelvin"
+const _Email = "mckelvin@users.noreply.github.com"
+const _Date = "Tue Nov 1 00:12:24 2016 +0800"
 
 // Version of the package
 const Version = _Version

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.0.1-10-g6753c61"
+const _Version = "v1.0.1-11-g7b0a034"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Tue Nov 1 00:12:24 2016 +0800"
+const _Date = "Tue Nov 1 00:14:39 2016 +0800"
 
 // Version of the package
 const Version = _Version

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.0.1-1-ga29a5c0"
-const _Author = "mckelvin"
-const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Tue Jun 28 11:03:35 2016 +0800"
+const _Version = "v1.0.1-8-g624ca73"
+const _Author = "youngsofun"
+const _Email = "yangxiufeng.c@gmail.com"
+const _Date = "Mon Jul 11 10:58:10 2016 +0800"
 
 // Version of the package
 const Version = _Version


### PR DESCRIPTION
The PR is expected to fix https://github.com/douban/libmc/issues/46 .

There's a feature in libmc named [lazy-connecting](https://github.com/douban/libmc/wiki/Features#lazy-connecting). TCP connections will not be established and value of `Connection.alive()` is `false` before its first network request (`get` / `set`). A Connection should try to establish (by calling `.tryReconnect()`) first before failover to next one. And the bug is: it's called only when failover is disabled. When failover is enabled, it'll skip the first server directly without trying to connect and will establish the connection for the next server by calling `tryReconnect()`.