### PR TITLE
raise exception when fail to encode_value/decode_value

### DIFF
--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -276,11 +276,8 @@ cdef bytes _encode_value(object val, int comp_threshold, flags_t *flags):
             enc_val = marshal.dumps(val, 2)
             flags[0] = _FLAG_MARSHAL
         except:
-            try:
-                enc_val = pickle.dumps(val, -1)
-                flags[0] = _FLAG_PICKLE
-            except:
-                pass
+            enc_val = pickle.dumps(val, -1)
+            flags[0] = _FLAG_PICKLE
 
     if comp_threshold > 0 and enc_val is not None and len(enc_val) > comp_threshold:
         enc_val = zlib.compress(enc_val)
@@ -290,7 +287,7 @@ cdef bytes _encode_value(object val, int comp_threshold, flags_t *flags):
 
 
 def encode_value(object val, int comp_threshold):
-    cdef flags_t flags
+    cdef flags_t flags = 0xffffffff
     cdef bytes buf = _encode_value(val, comp_threshold, &flags)
     return buf, flags
 
@@ -298,10 +295,7 @@ def encode_value(object val, int comp_threshold):
 cpdef object decode_value(bytes val, flags_t flags):
     cdef object dec_val = None
     if flags & _FLAG_COMPRESS:
-        try:
-            dec_val = zlib.decompress(val)
-        except zlib.error:
-            return
+        dec_val = zlib.decompress(val)
     else:
         dec_val = val
 
@@ -312,15 +306,9 @@ cpdef object decode_value(bytes val, flags_t flags):
     elif flags & _FLAG_LONG:
         dec_val = long(dec_val.decode('ascii'))
     elif flags & _FLAG_MARSHAL:
-        try:
-            dec_val = marshal.loads(dec_val)
-        except:
-            dec_val = None
+        dec_val = marshal.loads(dec_val)
     elif flags & _FLAG_PICKLE:
-        try:
-            dec_val = pickle.loads(dec_val)
-        except:
-            dec_val = None
+        dec_val = pickle.loads(dec_val)
     return dec_val
 
 

--- a/tests/test_cmemcached_regression.py
+++ b/tests/test_cmemcached_regression.py
@@ -241,6 +241,16 @@ class CmemcachedRegressionCase(unittest.TestCase):
         self.assertEqual(raw, pickle.dumps(v, -1))
         '''
 
+    def test_no_pickle(self):
+
+        class NoPickle(object):
+
+            def __getattr__(self, name):
+                pass
+
+        v = NoPickle()
+        self.assertRaises(TypeError, lambda: self.mc.set("nopickle", v))
+
     def test_marshal(self):
         v = [{2: {"a": 337}}]
         self.mc.set("a", v)

--- a/tests/test_cmemcached_regression.py
+++ b/tests/test_cmemcached_regression.py
@@ -32,12 +32,6 @@ class BigObject(object):
         return self.object == other.object
 
 
-class NoPickle(object):
-
-    def __getattr__(self, name):
-        pass
-
-
 class CmemcachedRegressionCase(unittest.TestCase):
 
     def setUp(self):
@@ -246,11 +240,6 @@ class CmemcachedRegressionCase(unittest.TestCase):
         raw, flags = self.mc.get_raw("a")
         self.assertEqual(raw, pickle.dumps(v, -1))
         '''
-
-    def test_no_pickle(self):
-        v = NoPickle()
-        self.assertEqual(self.mc.set("nopickle", v), None)
-        self.assertEqual(self.mc.get("nopickle"), None)
 
     def test_marshal(self):
         v = [{2: {"a": 337}}]


### PR DESCRIPTION
1.  it seems not necessary to suppress exceptions and just return None
2. in get: return None, can not distinguish client error(not import some class) from  "not exist" 
3. in set: return None and an uninitialized  "flag"