### PR TITLE
fix rvalue reference

### DIFF
--- a/include/BufferWriter.h
+++ b/include/BufferWriter.h
@@ -23,11 +23,7 @@ class BufferWriter {
   void reserve(size_t n);
   void takeBuffer(const char* const buf, size_t buf_len);
   void takeNumber(int64_t val);
-#ifdef __APPLE__
-  const struct iovec* const getReadPtr(int &n);
-#else
   const struct iovec* const getReadPtr(size_t &n);
-#endif
   void commitRead(size_t nSent);
   size_t msgIovlen();
 
@@ -36,11 +32,7 @@ class BufferWriter {
   std::vector<char*>  m_unsignedStringList;
   size_t m_readIdx;
 
-#ifdef __APPLE__
-  int m_msgIovlen;
-#else
   size_t m_msgIovlen;
-#endif
 };
 
 

--- a/src/BufferWriter.cpp
+++ b/src/BufferWriter.cpp
@@ -56,11 +56,7 @@ void BufferWriter::takeNumber(int64_t val) {
 }
 
 
-#ifdef __APPLE__
-const struct iovec* const BufferWriter::getReadPtr(int &n) {
-#else
 const struct iovec* const BufferWriter::getReadPtr(size_t &n) {
-#endif
   n = m_msgIovlen;
   if (n > 0) {
     return &m_iovec[m_readIdx];

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -1,6 +1,7 @@
+#include "Common.h"
+#ifdef __GLIBC__
 #include <execinfo.h>
 #include <cstdlib>
-#include "Common.h"
 
 
 void printBacktrace() {
@@ -12,3 +13,6 @@ void printBacktrace() {
   }
   free(stack_syms);
 }
+#else
+void printBacktrace() {}
+#endif

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -231,7 +231,9 @@ void Connection::takeNumber(int64_t val) {
 ssize_t Connection::send() {
   struct msghdr msg = {};
 
-  msg.msg_iov = const_cast<struct iovec *>(m_buffer_writer->getReadPtr(msg.msg_iovlen));
+  size_t n = 0;
+  msg.msg_iov = const_cast<struct iovec *>(m_buffer_writer->getReadPtr(n));
+  msg.msg_iovlen = n;
 
   // otherwise may lead to EMSGSIZE, SEE issue#3 on code
   int flags = 0;


### PR DESCRIPTION
Fix compile error on alpine linux, the error is following:

```shell
pip install libmc
Collecting libmc
  Using cached libmc-1.1.0.tar.gz
Installing collected packages: libmc
  Running setup.py install for libmc ... error
    Complete output from command /usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-0reiZW/libmc/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-0brqPz-record/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-2.7
    creating build/lib.linux-x86_64-2.7/libmc
    copying libmc/__init__.py -> build/lib.linux-x86_64-2.7/libmc
    running build_ext
    cythoning libmc/_client.pyx to libmc/_client.cpp
    building 'libmc._client' extension
    creating build/temp.linux-x86_64-2.7
    creating build/temp.linux-x86_64-2.7/src
    creating build/temp.linux-x86_64-2.7/libmc
    gcc -fno-strict-aliasing -Os -fomit-frame-pointer -g -DNDEBUG -Os -fomit-frame-pointer -g -fPIC -Iinclude -I/usr/include/python2.7 -c src/BufferReader.cpp -o build/temp.linux-x86_64-2.7/src/BufferReader.o -fno-strict-aliasing -fno-exceptions -fno-rtti -Wall -DMC_USE_SMALL_VECTOR -O3 -DNDEBUG
    gcc -fno-strict-aliasing -Os -fomit-frame-pointer -g -DNDEBUG -Os -fomit-frame-pointer -g -fPIC -Iinclude -I/usr/include/python2.7 -c src/Connection.cpp -o build/temp.linux-x86_64-2.7/src/Connection.o -fno-strict-aliasing -fno-exceptions -fno-rtti -Wall -DMC_USE_SMALL_VECTOR -O3 -DNDEBUG
    In file included from src/Connection.cpp:6:0:
    /usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
     #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      ^~~~~~~
    src/Connection.cpp: In member function 'ssize_t douban::mc::Connection::send()':
    src/Connection.cpp:234:76: error: invalid initialization of non-const reference of type 'size_t& {aka long unsigned int&}' from an rvalue of type 'size_t {aka long unsigned int}'
       msg.msg_iov = const_cast<struct iovec *>(m_buffer_writer->getReadPtr(msg.msg_iovlen));
                                                                            ~~~~^~~~~~~~~~
    In file included from include/Connection.h:11:0,
                     from src/Connection.cpp:13:
    include/BufferWriter.h:29:29: note:   initializing argument 1 of 'const iovec* const douban::mc::io::BufferWriter::getReadPtr(size_t&)'
       const struct iovec* const getReadPtr(size_t &n);
                                 ^~~~~~~~~~
    error: command 'gcc' failed with exit status 1

    ----------------------------------------
Command "/usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-0reiZW/libmc/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-0brqPz-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-0reiZW/libmc/
```
This PR also check if `glibc` is exists.
@youngsofun @MOON-CLJ plz review