### PR TITLE
make normalize_key cpdef & add warnings for unpickle unmarshal fail

### DIFF
--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -438,9 +438,9 @@ cdef class PyClient:
         PyString_AsStringAndSize(key2, &c_key, <Py_ssize_t*>&c_key_len)
         with nogil:
             c_addr = self._imp.getServerAddressByKey(c_key, c_key_len)
-        cdef basestring c_server_addr = c_addr
+        cdef basestring server_addr = c_addr
         Py_DECREF(key2)
-        return c_server_addr
+        return server_addr
 
     def get_realtime_host_by_key(self, basestring key):
         cdef bytes key2 = self.normalize_key(key)
@@ -452,10 +452,10 @@ cdef class PyClient:
         with nogil:
             c_addr = self._imp.getRealtimeServerAddressByKey(c_key, c_key_len)
         Py_DECREF(key2)
-        cdef basestring c_server_addr
+        cdef basestring server_addr
         if c_addr != NULL:
-            c_server_addr = c_addr
-            return c_server_addr
+            server_addr = c_addr
+            return server_addr
 
     cpdef normalize_key(self, basestring raw_key):
         cdef bytes key

--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -62,7 +62,6 @@ cdef extern from "Export.h":
     ctypedef uint64_t cas_unique_t
 
     ctypedef struct retrieval_result_t:
-        retrieval_result_t()
         char* key
         uint8_t key_len
         flags_t flags
@@ -116,8 +115,8 @@ cdef extern from "Client.h" namespace "douban::mc":
                  const char* const * aliases) nogil
         int updateServers(const char* const * hosts, const uint32_t* ports, size_t n,
                           const char* const * aliases) nogil
-        char* getServerAddressByKey(const char* key, size_t keyLen) nogil
-        char* getRealtimeServerAddressByKey(const char* key, size_t keyLen) nogil
+        char* getServerAddressByKey(const char* key, const size_t keyLen) nogil
+        char* getRealtimeServerAddressByKey(const char* key, const size_t keyLen) nogil
         void enableConsistentFailover() nogil
         void disableConsistentFailover() nogil
         err_code_t get(
@@ -200,7 +199,7 @@ cdef extern from "Client.h" namespace "douban::mc":
             size_t* nResults
         ) nogil
         void destroyUnsignedResult() nogil
-        void _sleep(uint32_t ms) nogil
+        void _sleep(uint32_t seconds) nogil
 
 cdef uint32_t MC_DEFAULT_PORT = 11211
 cdef flags_t _FLAG_EMPTY = 0
@@ -458,7 +457,7 @@ cdef class PyClient:
             c_server_addr = c_addr
             return c_server_addr
 
-    cdef normalize_key(self, basestring raw_key):
+    cpdef normalize_key(self, basestring raw_key):
         cdef bytes key
         if isinstance(raw_key, unicode):
             key = raw_key.encode(self.encoding)
@@ -1040,7 +1039,6 @@ cdef class PyClient:
 
     def clear_thread_ident(self):
         self._thread_ident = None
-        self._thread_ident_stack = None
 
     def _record_thread_ident(self):
         if self._thread_ident is None:


### PR DESCRIPTION
warnings.warn for unpickle & unmarshal fail, and only first time for each line of the caller code。

```
>>> import warnings
>>> warnings.warn("once")
__main__:1: UserWarning: once
>>> warnings.warn("once")
>>> warnings.warn("another")
__main__:1: UserWarning: another
>>> warnings.warn("another")
```

```
(venv) chenlijun@redis00 ~/libmc $ python tmp.py
db:foo
tmp.py:7: UserWarning: [libmc] unpickle failed. err:ValueError('insecure string pickle',)
  mc.get('foo')
(venv) chenlijun@redis00 ~/libmc $ cat tmp.py
import libmc
import pickle

mc = libmc.Client(['nain2:11221'], prefix=u'db:')
print mc.normalize_key('foo')
mc.set_raw('foo', pickle.dumps("aaa")[:3], 3600, 1 << 0)
mc.get('foo')
```
