### PR TITLE
split cppcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ cache:
     - $HOME/.cache/pip
     - $HOME/.pip-cache/
     - $HOME/virtualenv/python2.7/lib/python2.7/site-packages
+    - $HOME/virtualenv/python3.5/lib/python3.5/site-packages
 
 env:
   matrix:
+  - TEST_SUITE=cppcheck
   - TEST_SUITE=unittest CMAKE_BUILD_TYPE=Release PRJ_COMPILER=clang
   - TEST_SUITE=unittest CMAKE_BUILD_TYPE=Debug PRJ_COMPILER=clang
   - TEST_SUITE=unittest CMAKE_BUILD_TYPE=Release PRJ_COMPILER=gcc
@@ -29,22 +31,21 @@ addons:
       - golang
 
 install:
-  - pip install --upgrade pip
-  - pip install future
-  - pip install --upgrade setuptools
-  - if [ $TEST_SUITE = "unittest" ]; then pip install pytest greenify gevent; fi
-  - if [ $TEST_SUITE = "benchmark" ]; then pip install python-memcached pylibmc; fi
+  - if [[ $TEST_SUITE != "cppcheck" ]]; then pip install --upgrade pip setuptools; fi
+  - if [[ $TEST_SUITE != "cppcheck" ]]; then pip install future; fi
+  - if [[ $TEST_SUITE = "unittest" ]]; then pip install pytest greenify gevent; fi
+  - if [[ $TEST_SUITE = "benchmark" ]]; then pip install python-memcached pylibmc; fi
 
 before_script:
-  - ./misc/memcached_server start
+  - if [[ $TEST_SUITE != "cppcheck" ]]; then ./misc/memcached_server start; fi
 
 script:
-  - if [ $PRJ_COMPILER = "gcc" ]; then export CC=gcc CXX=g++; fi
-  - if [ $PRJ_COMPILER = "clang" ]; then export CC=clang CXX=clang++; fi
+  - if [[ $PRJ_COMPILER = "gcc" ]]; then export CC=gcc CXX=g++; fi
+  - if [[ $PRJ_COMPILER = "clang" ]]; then export CC=clang CXX=clang++; fi
   - ./misc/travis/$TEST_SUITE.sh
 
 after_script:
-  - ./misc/memcached_server stop
+  - if [[ $TEST_SUITE != "cppcheck" ]]; then ./misc/memcached_server stop; fi
 
 deploy:
   provider: pypi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+cppcheck:
+	./misc/travis/cppcheck.sh

--- a/misc/travis/cppcheck.sh
+++ b/misc/travis/cppcheck.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -x
+set -e
+cppcheck --enable=all --std=c99 --error-exitcode=1 \
+    --suppressions-list=misc/.cppcheck-supp -Iinclude src tests

--- a/misc/travis/unittest.sh
+++ b/misc/travis/unittest.sh
@@ -3,8 +3,6 @@ set -x
 set -e
 echo $CXX
 go version
-cppcheck --enable=all --std=c99 --error-exitcode=1 \
-    --suppressions-list=misc/.cppcheck-supp -Iinclude src tests
 python misc/generate_hash_dataset.py tests/resources/keys.txt
 mkdir -p build
 cd build


### PR DESCRIPTION
cppcheck will run for one minute and no need to run in unittest matrix。

cppcheck still run twice because py2 and py3. I don't figure out how to configure multi language, such as add one more language C++ in `.travis.yml` only run cppcheck. I tried https://stackoverflow.com/a/44054333, but it dont work.

cc @everpcpc