### PR TITLE
fix fcntl usage when set socket nonblock

### DIFF
--- a/misc/.cppcheck-supp
+++ b/misc/.cppcheck-supp
@@ -24,8 +24,6 @@ unusedFunction:src/c_client.cpp:106
 unusedFunction:src/c_client.cpp:72
 unusedFunction:src/c_client.cpp:135
 unusedFunction:src/c_client.cpp:67
-unusedFunction:src/c_client.cpp:43
-unusedFunction:src/c_client.cpp:37
 unusedFunction:src/c_client.cpp:68
 unusedFunction:src/c_client.cpp:120
 unusedFunction:src/c_client.cpp:13
@@ -39,9 +37,9 @@ unusedFunction:src/c_client.cpp:50
 unusedFunction:src/Utility.cpp:43
 constStatement:src/BufferReader.cpp:27
 constStatement:src/BufferReader.cpp:48
-constStatement:src/Connection.cpp:180
-constStatement:src/Connection.cpp:199
-constStatement:src/Connection.cpp:204
+constStatement:src/Connection.cpp:173
+constStatement:src/Connection.cpp:192
+constStatement:src/Connection.cpp:197
 constStatement:src/ConnectionPool.cpp:436
 constStatement:src/DataBlock.cpp:52
 constStatement:src/HashkitKetama.cpp:136

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1,7 +1,6 @@
 #include <unistd.h>
 #include <vector>
 
-#include "Export.h"
 #include "Common.h"
 #include "Client.h"
 #include "Keywords.h"
@@ -30,6 +29,7 @@ void Client::config(config_options_t opt, int val) {
       break;
     case CFG_HASH_FUNCTION:
       ConnectionPool::setHashFunction(static_cast<hash_function_options_t>(val));
+      break;
     default:
       break;
   }


### PR DESCRIPTION
cc @everpcpc

from fcntl man page

```
       EINTR  For F_SETLKW, the command was interrupted by a signal; see
       signal(7).  For F_GETLK and F_SETLK, the command was interrupted
       by a signal  before  the
       lock was checked or acquired.  Most likely when
       locking a remote file (e.g., locking over NFS), but
       can sometimes happen locally.

       EINVAL For F_DUPFD, arg is negative or is
       greater than the maximum allowable value.
       For F_SETSIG, arg is not an allowable signal
       number.
```

so i dont think cmd F_GETFL & F_SETFL will encounter EINTR or EAGAIN,
so just move the do while loop will do the same thing as before.
i see redis source
code，https://github.com/antirez/redis/blob/565e139a5631a777254e222d1c50ea6d696e1a8e/src/anet.c#L77

it's just like

```
    if (fcntl(fd, F_SETFL, flags) == -1) {
        anetSetError(err, "fcntl(F_SETFL,O_NONBLOCK): %s", strerror(errno));
        return ANET_ERR;
    }
```

so i think it's safe to do so。

this pr include some other minor fix.

 - str_port's init args from "\0" to "", i think "" just means "\0"
   for c char array literal.

 - max_timeout 6 to 3，i think 6 is too much, for example
   m_connectTimeout is 300ms in douban's mc config.