### PR TITLE
Avoid noisy recv_err when broadcast quit

### DIFF
--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -33,7 +33,7 @@ class ConnectionPool {
                      const exptime_t exptime, const bool noreply, size_t nItems);
   void dispatchIncrDecr(op_code_t op, const char* key, const size_t keyLen,
                         const uint64_t delta, const bool noreply);
-  void broadcastCommand(const char * const cmd, const size_t cmdLens);
+  void broadcastCommand(const char * const cmd, const size_t cmdLens, const bool noreply=false);
 
   err_code_t waitPoll();
 
@@ -47,7 +47,7 @@ class ConnectionPool {
   void setRetryTimeout(int timeout);
 
  protected:
-  void markDeadAll(pollfd_t* pollfds, const char*);
+  void markDeadAll(pollfd_t* pollfds, const char* reason);
   void markDeadConn(Connection* conn, const char* reason, pollfd_t* fd_ptr);
 
   uint32_t m_nActiveConn; // wait for poll

--- a/include/Keywords.h
+++ b/include/Keywords.h
@@ -44,6 +44,8 @@ static const char kPOLL_TIMEOUT[] = "poll_timeout";
 static const char kPOLL_ERROR[] = "poll_error";
 static const char kPROGRAMMING_ERROR[] = "programming_error";
 
+static const char kCONN_QUIT[] = "conn_quit";
+
 } // namespace keywords
 } // namespace mc
 } // namespace douban

--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -943,9 +943,7 @@ cdef class PyClient:
         with nogil:
             self.last_error = self._imp.quit()
             self._imp.destroyBroadcastResult()
-        if self.last_error in {RET_CONN_POLL_ERR, RET_RECV_ERR}:
-            return True
-        return False
+        return self.last_error in {RET_CONN_POLL_ERR, RET_OK}
 
     def stats(self):
         self._record_thread_ident()

--- a/misc/.cppcheck-supp
+++ b/misc/.cppcheck-supp
@@ -10,7 +10,7 @@
 *:include/llvm/SmallVector.h:726
 *:include/llvm/SmallVector.h:735
 *:include/llvm/SmallVector.h:796
-unusedFunction:src/Client.cpp:215
+unusedFunction:src/Client.cpp:216
 unusedFunction:src/c_client.cpp:90
 unusedFunction:src/c_client.cpp:92
 unusedFunction:src/c_client.cpp:94
@@ -39,9 +39,10 @@ unusedFunction:src/c_client.cpp:50
 unusedFunction:src/Utility.cpp:43
 constStatement:src/BufferReader.cpp:27
 constStatement:src/BufferReader.cpp:48
-constStatement:src/Connection.cpp:179
-constStatement:src/Connection.cpp:202
-constStatement:src/ConnectionPool.cpp:408
+constStatement:src/Connection.cpp:180
+constStatement:src/Connection.cpp:199
+constStatement:src/Connection.cpp:204
+constStatement:src/ConnectionPool.cpp:410
 constStatement:src/DataBlock.cpp:52
 constStatement:src/HashkitKetama.cpp:136
 constStatement:src/Utility.cpp:17

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -149,8 +149,9 @@ err_code_t Client::version(broadcast_result_t** results, size_t* nHosts) {
 
 
 err_code_t Client::quit() {
-  broadcastCommand(keywords::kQUIT, 4);
+  broadcastCommand(keywords::kQUIT, 4, true);
   err_code_t rv = waitPoll();
+  markDeadAll(NULL, keywords::kCONN_QUIT);
   return rv;
 }
 

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -11,6 +11,7 @@
 #include <queue>
 
 #include "Connection.h"
+#include "Keywords.h"
 
 using douban::mc::io::BufferWriter;
 using douban::mc::io::BufferReader;
@@ -193,13 +194,15 @@ void Connection::markDead(const char* reason, int delay) {
     time(&m_deadUntil);
     m_deadUntil += delay; // check after `delay` seconds, default 0
     this->close();
-    log_warn("Connection %s is dead(reason: %s, delay: %d), next check at %lu",
-             m_name, reason, delay, m_deadUntil);
-    std::queue<struct iovec>* q = m_parser.getRequestKeys();
-    if (!q->empty()) {
-      log_warn("%s: first request key: %.*s", m_name,
-               static_cast<int>(q->front().iov_len),
-               static_cast<char*>(q->front().iov_base));
+    if (strcmp(reason, keywords::kCONN_QUIT) != 0) {
+      log_warn("Connection %s is dead(reason: %s, delay: %d), next check at %lu",
+               m_name, reason, delay, m_deadUntil);
+      std::queue<struct iovec>* q = m_parser.getRequestKeys();
+      if (!q->empty()) {
+        log_warn("%s: first request key: %.*s", m_name,
+                 static_cast<int>(q->front().iov_len),
+                 static_cast<char*>(q->front().iov_base));
+      }
     }
   }
 }

--- a/src/golibmc.go
+++ b/src/golibmc.go
@@ -1376,12 +1376,11 @@ func (cn *conn) quit() error {
 	cn.client.lk.Lock()
 	defer cn.client.lk.Unlock()
 	cn.client.numOpen--
-	err := networkError(errorMessage[errCode])
-	if isBadConnErr(err) {
+	if errCode == C.RET_OK || errCode == C.RET_CONN_POLL_ERR {
 		cn.client.maybeOpenNewConnections()
 		return nil
 	}
-	return err
+	return networkError(errorMessage[errCode])
 }
 
 func isBadConnErr(err error) (r bool) {

--- a/src/golibmc_test.go
+++ b/src/golibmc_test.go
@@ -828,13 +828,22 @@ func testQuit(mc, mc2 *Client, t *testing.T) {
 		t.Errorf("Error in Quit: %s", err)
 	}
 
-	st2, err := mc2.Stats()
-	if err != nil {
-		t.Error(err)
-	}
-	nc2, err = strconv.Atoi(st2[LocalMC]["curr_connections"])
-	if err != nil {
-		t.Error(err)
+	for i := 0; i < 3; i++ {
+		st2, err := mc2.Stats()
+		if err != nil {
+			t.Error(err)
+			break
+		}
+		nc2, err = strconv.Atoi(st2[LocalMC]["curr_connections"])
+		if err != nil {
+			t.Error(err)
+			break
+		}
+		if nc1-1 == nc2 {
+			break
+		} else {
+			time.Sleep(time.Second)
+		}
 	}
 
 	if nc1-1 != nc2 {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import sys
+import time
 import unittest
 from libmc import (
     Client, encode_value, decode_value,
@@ -242,7 +243,11 @@ class SingleServerCase(unittest.TestCase):
         nc2 = self.mc_alt.stats()[self.mc.servers[0]]['curr_connections']
         assert nc1 == nc2
         assert self.mc.quit()
-        nc2 = self.mc_alt.stats()[self.mc.servers[0]]['curr_connections']
+        max_wait = 3
+        while nc1 - 1 != nc2 and max_wait > 0:
+            nc2 = self.mc_alt.stats()[self.mc.servers[0]]['curr_connections']
+            max_wait -= 1
+            time.sleep(1)
         assert nc1 - 1 == nc2
         # back to life immediately
         assert self.mc.get('all_is_well') == 'bingo'


### PR DESCRIPTION
cc @everpcpc 

after broadcast quit command, server will close connection
properly, then if waitPoll wait for input and call recv, recv will return 0, will cause
numOfConnections recv_errors. i confirm this from logging.

quit cmd shouldn't expect reply。

noisy recv_errs like https://gist.github.com/MOON-CLJ/aab57cbc6af289610160f4a2e87f3fe8。