### PR TITLE
explict issue gtest version

### DIFF
--- a/ext/gtest/CMakeLists.txt.in
+++ b/ext/gtest/CMakeLists.txt.in
@@ -5,7 +5,7 @@ include(ExternalProject)
 
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG master
+    GIT_TAG 2fe3bd994b3189899d93f1d5a881e725e046fdc2  # tag release-1.8.1
     SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
     CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs


### PR DESCRIPTION
googletest master requires C++11。

and 

"1.8.x Release - the 1.8.x will be the last release that works with pre-C++11 compilers. The 1.8.x will not accept any requests for any new features and any bugfix requests will only be accepted if proven "critical""

libmc should use 1.8.x up to now。

https://github.com/douban/libmc/pull/84 's test failure is  related to this pr。