### PR TITLE
Add comments for golibmc's connection pool implementation

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -31,7 +31,7 @@ __VERSION__ = "1.2.0"
 __version__ = "v1.2.0"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Mon Feb 18 17:42:37 2019 +0800"
+__date__ = "Mon Feb 18 18:44:32 2019 +0800"
 
 
 class Client(PyClient):

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.2.0"
-__version__ = "v1.2.0"
+__version__ = "v1.2.0-1-gbb3eb43"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Mon Feb 18 18:44:32 2019 +0800"
+__date__ = "Fri Feb 22 10:40:56 2019 +0800"
 
 
 class Client(PyClient):

--- a/misc/graph_all.sh
+++ b/misc/graph_all.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+gen_graph () {
+  gprof2dot --format=callgrind --output=$2 $1
+  dot -Tpng $2 -o $3
+
+  echo Gen graph $3
+}
+
+for i in `ls callgrind.out.*`; do
+  seq=${i##callgrind.out.}
+  dot_filename=out.dot.$seq
+  graph_filename=graph.$seq.png
+  if ! [[ -f $graph_filename ]]; then
+    gen_graph $i $dot_filename $graph_filename
+  fi
+done

--- a/src/version.go
+++ b/src/version.go
@@ -3,7 +3,7 @@ package golibmc
 const _Version = "v1.2.0"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Mon Feb 18 17:42:37 2019 +0800"
+const _Date = "Mon Feb 18 18:44:32 2019 +0800"
 
 // Version of the package
 const Version = _Version

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.2.0"
+const _Version = "v1.2.0-1-gbb3eb43"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Mon Feb 18 18:44:32 2019 +0800"
+const _Date = "Fri Feb 22 10:40:56 2019 +0800"
 
 // Version of the package
 const Version = _Version


### PR DESCRIPTION
This PR is mainly add comments for golibmc's connection pool implementation.
Take it as a supplementary of https://github.com/douban/libmc/pull/57.

It takes a lot of comments from the original code https://github.com/golang/go/blob/master/src/database/sql/sql.go , and adds some `FIXME`.