### PR TITLE
fixup golibmc ConfigTimeout unit

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.2.0"
-__version__ = "v1.2.0-3-gfa59170"
+__version__ = "v1.2.0-4-g53b322b"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Mon Feb 25 16:26:10 2019 +0800"
+__date__ = "Mon Feb 25 18:43:03 2019 +0800"
 
 
 class Client(PyClient):

--- a/src/golibmc.go
+++ b/src/golibmc.go
@@ -659,10 +659,9 @@ func (client *Client) ConfigTimeout(cCfgKey C.config_options_t, timeout time.Dur
 	case RetryTimeout:
 		client.retryTimeout = C.int(timeout / time.Second)
 	case PollTimeout:
-		// FIXME(Harry): should use time.Millisecond
-		client.pollTimeout = C.int(timeout / time.Microsecond)
+		client.pollTimeout = C.int(timeout / time.Millisecond)
 	case ConnectTimeout:
-		client.connectTimeout = C.int(timeout / time.Microsecond)
+		client.connectTimeout = C.int(timeout / time.Millisecond)
 	}
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.2.0-3-gfa59170"
+const _Version = "v1.2.0-4-g53b322b"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Mon Feb 25 16:26:10 2019 +0800"
+const _Date = "Mon Feb 25 18:43:03 2019 +0800"
 
 // Version of the package
 const Version = _Version

--- a/tests/golibmc_debug_client.go
+++ b/tests/golibmc_debug_client.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	golibmc "github.com/douban/libmc/src"
+	"time"
+)
+
+func newClient() *golibmc.Client {
+	noreply := false
+	prefix := ""
+	hashFunc := golibmc.HashMD5
+	failover := false
+	disableLock := false
+
+	SERVERS := []string{"sa-dev:1 mc-server-will-timeout"}
+	// SERVERS := []string{"localhost:21211 mc-server-local"}
+
+	CONNECT_TIMEOUT := 10
+	// CONNECT_TIMEOUT := 1000
+	POLL_TIMEOUT := 300
+	RETRY_TIMEOUT := 5
+
+	client := golibmc.New(SERVERS, noreply, prefix, hashFunc, failover, disableLock)
+	client.ConfigTimeout(golibmc.ConnectTimeout, time.Duration(CONNECT_TIMEOUT)*time.Millisecond)
+	client.ConfigTimeout(golibmc.PollTimeout, time.Duration(POLL_TIMEOUT)*time.Millisecond)
+	client.ConfigTimeout(golibmc.RetryTimeout, time.Duration(RETRY_TIMEOUT)*time.Second)
+	return client
+}
+
+func main() {
+	client := newClient()
+
+	key := "hello"
+	val := "world"
+
+	err := client.Set(&golibmc.Item{Key: key, Value: []byte(val)})
+	if err != nil {
+		fmt.Printf("ERROR: client.Set: %v\n", err)
+	}
+
+	item, err2 := client.Get(key)
+	if err2 != nil {
+		fmt.Printf("ERROR: client.Get: %v\n", err2)
+	} else {
+		fmt.Println(string(item.Value))
+	}
+}

--- a/tests/golibmc_debug_client.go
+++ b/tests/golibmc_debug_client.go
@@ -1,3 +1,5 @@
+// A standalone client using golibmc which aims to do ad-hoc trials.
+
 package main
 
 import (
@@ -13,7 +15,10 @@ func newClient() *golibmc.Client {
 	failover := false
 	disableLock := false
 
-	SERVERS := []string{"sa-dev:1 mc-server-will-timeout"}
+	// The following is an arbitrary server:port which cannot reach,
+	// so it will timeout when we connect
+	SERVERS := []string{"1.1.1.1:1 mc-server-will-timeout"}
+
 	// SERVERS := []string{"localhost:21211 mc-server-local"}
 
 	CONNECT_TIMEOUT := 10


### PR DESCRIPTION
We should use `time.Millisecond ` instead of `time.Microsecond` for `PollTimeout` and `ConnectTimeout`.
This bug will cause golibmc's timeout be 1000 times greater, which means our former timeout of golibmc is nearly not working at all.