### PR TITLE
Implement flush_all feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 bench_venv/
 _client.cpp
 _client.so
+_client.*.so
 .tox/
 
 .cache/

--- a/ext/gtest/CMakeLists.txt.in
+++ b/ext/gtest/CMakeLists.txt.in
@@ -5,7 +5,7 @@ include(ExternalProject)
 
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG master
+    GIT_TAG release-1.8.0
     SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
     CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs

--- a/include/Client.h
+++ b/include/Client.h
@@ -50,6 +50,7 @@ DECL_RETRIEVAL_CMD(gets)
   err_code_t version(broadcast_result_t** results, size_t* nHosts);
   err_code_t quit();
   err_code_t stats(broadcast_result_t** results, size_t* nHosts);
+  err_code_t flushAll(broadcast_result_t** results, size_t* nHosts);
 
   // touch
   err_code_t touch(const char* const* keys, const size_t* keyLens,
@@ -65,18 +66,23 @@ DECL_RETRIEVAL_CMD(gets)
            const bool noreply,
            unsigned_result_t** result, size_t* nResults);
 
+  inline void toggleFlushAllFeature(bool enabled) {
+    m_flushAllEnabled = enabled;
+  }
   void _sleep(uint32_t seconds); // check GIL in Python
 
  protected:
   void collectRetrievalResult(retrieval_result_t*** results, size_t* nResults);
   void collectMessageResult(message_result_t*** results, size_t* nResults);
-  void collectBroadcastResult(broadcast_result_t** results, size_t* nHosts);
+  void collectBroadcastResult(broadcast_result_t** results, size_t* nHosts, bool isFlushAll=false);
   void collectUnsignedResult(unsigned_result_t** results, size_t* nResults);
 
   std::vector<retrieval_result_t*> m_outRetrievalResultPtrs;
   std::vector<message_result_t*> m_outMessageResultPtrs;
   std::vector<broadcast_result_t> m_outBroadcastResultPtrs;
   std::vector<unsigned_result_t*> m_outUnsignedResultPtrs;
+
+  bool m_flushAllEnabled;
 };
 
 } // namespace mc

--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -41,7 +41,7 @@ class ConnectionPool {
 
   void collectRetrievalResult(std::vector<retrieval_result_t*>& results);
   void collectMessageResult(std::vector<message_result_t*>& results);
-  void collectBroadcastResult(std::vector<broadcast_result_t>& results);
+  void collectBroadcastResult(std::vector<broadcast_result_t>& results, bool isFlushAll=false);
   void collectUnsignedResult(std::vector<unsigned_result_t*>& results);
   void reset();
   void setPollTimeout(int timeout);

--- a/include/Export.h
+++ b/include/Export.h
@@ -45,14 +45,6 @@ typedef uint64_t cas_unique_t;
 
 
 typedef struct {
-  char* host;
-  char** lines;
-  size_t* line_lens;
-  size_t len;
-} broadcast_result_t;
-
-
-typedef struct {
   char* key; // 8B
   char* data_block; // 8B
   cas_unique_t cas_unique; // 8B
@@ -63,7 +55,8 @@ typedef struct {
 
 
 enum message_result_type {
-  MSG_EXISTS,
+  MSG_LIBMC_INVALID = -1,
+  MSG_EXISTS = 0,
   MSG_OK,
   MSG_STORED,
   MSG_NOT_STORED,
@@ -85,3 +78,16 @@ typedef struct {
   size_t key_len;
   uint64_t value;
 } unsigned_result_t;
+
+
+// For flush_all command, we need to specify
+// {host} and {msg_type},
+// for other broadcast commands, we need to specify
+// all fields except {msg_type}
+typedef struct {
+  char* host;
+  char** lines;
+  size_t* line_lens;
+  size_t len;
+  enum message_result_type msg_type;  // for flush_all command
+} broadcast_result_t;

--- a/include/Keywords.h
+++ b/include/Keywords.h
@@ -31,6 +31,7 @@ static const char k_NOREPLY[] = " noreply";
 
 static const char kVERSION[] = "version";
 static const char kSTATS[] = "stats";
+static const char kFLUSHALL[] = "flush_all";
 
 static const char kQUIT[] = "quit";
 

--- a/include/c_client.h
+++ b/include/c_client.h
@@ -63,6 +63,8 @@ extern "C" {
   void client_destroy_unsigned_result(void* client);
 
   err_code_t client_stats(void* client, broadcast_result_t** results, size_t* n_servers);
+  void client_toggle_flush_all_feature(void* client, bool enabled);
+  err_code_t client_flush_all(void* client, broadcast_result_t** results, size_t* n_servers);
   err_code_t client_quit(void* client);
 
   const char* err_code_to_string(err_code_t err);

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -28,10 +28,10 @@ from ._client import (
 )
 
 __VERSION__ = "1.2.0"
-__version__ = "v1.2.1"
+__version__ = "v1.2.1-4-gc3c6500"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
-__date__ = "Wed Mar 13 14:40:14 2019 +0800"
+__date__ = "Tue Jul 30 14:06:44 2019 +0800"
 
 
 class Client(PyClient):

--- a/misc/update_version.sh
+++ b/misc/update_version.sh
@@ -7,8 +7,8 @@ for VERSIONING_FILE in $VERSIONING_FILES
 do
     TMPFILE=$VERSIONING_FILE".2"
     cat $VERSIONING_FILE | \
-        python $VERSIONING_SCRIPT --clean | \
-        python $VERSIONING_SCRIPT > $TMPFILE
+        python2 $VERSIONING_SCRIPT --clean | \
+        python2 $VERSIONING_SCRIPT > $TMPFILE
     mv $TMPFILE $VERSIONING_FILE
     git add $VERSIONING_FILE
 done

--- a/misc/versioning.py
+++ b/misc/versioning.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # from: https://gist.githubusercontent.com/pkrusche/7369262/raw/5bf2dc8afb88d3fdde7be6d16ee4290db6735f37/versioning.py
 
 """ Git Versioning Script

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import os
 import re
 import sys
+import shlex
 import pkg_resources
 from glob import glob
 from setuptools import setup, Extension
@@ -56,7 +57,7 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = ['tests']
+        self.pytest_args = 'tests'
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -66,7 +67,7 @@ class PyTest(TestCommand):
     def run_tests(self):
         #import here, cause outside the eggs aren't loaded
         import pytest
-        errno = pytest.main(self.pytest_args)
+        errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
 setup(

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -8,7 +8,7 @@
 namespace douban {
 namespace mc {
 
-Client::Client() {
+Client::Client(): m_flushAllEnabled(false) {
 }
 
 
@@ -125,10 +125,10 @@ err_code_t Client::_delete(const char* const* keys, const size_t* keyLens,
 }
 
 
-void Client::collectBroadcastResult(broadcast_result_t** results, size_t* nHosts) {
+void Client::collectBroadcastResult(broadcast_result_t** results, size_t* nHosts, bool isFlushAll) {
   assert(m_outBroadcastResultPtrs.empty());
   *nHosts = m_nConns;
-  ConnectionPool::collectBroadcastResult(m_outBroadcastResultPtrs);
+  ConnectionPool::collectBroadcastResult(m_outBroadcastResultPtrs, isFlushAll);
   *results = &m_outBroadcastResultPtrs.front();
 }
 
@@ -163,6 +163,19 @@ err_code_t Client::stats(broadcast_result_t** results, size_t* nHosts) {
   broadcastCommand(keywords::kSTATS, 5);
   err_code_t rv = waitPoll();
   collectBroadcastResult(results, nHosts);
+  return rv;
+}
+
+err_code_t Client::flushAll(broadcast_result_t** results, size_t* nHosts) {
+  if (!m_flushAllEnabled) {
+    *results = NULL;
+    *nHosts = 0;
+    return RET_PROGRAMMING_ERR;
+  }
+
+  broadcastCommand(keywords::kFLUSHALL, 9);
+  err_code_t rv = waitPoll();
+  collectBroadcastResult(results, nHosts, true);
   return rv;
 }
 

--- a/src/c_client.cpp
+++ b/src/c_client.cpp
@@ -142,6 +142,15 @@ err_code_t client_stats(void* client, broadcast_result_t** results, size_t* n_se
   return c->stats(results, n_servers);
 }
 
+void client_toggle_flush_all_feature(void* client, bool enabled) {
+  douban::mc::Client* c = static_cast<Client*>(client);
+  return c->toggleFlushAllFeature(enabled);
+}
+err_code_t client_flush_all(void* client, broadcast_result_t** results, size_t* n_servers) {
+  douban::mc::Client* c = static_cast<Client*>(client);
+  return c->flushAll(results, n_servers);
+}
+
 err_code_t client_quit(void* client) {
   douban::mc::Client* c = static_cast<Client*>(client);
   return c->quit();

--- a/src/version.go
+++ b/src/version.go
@@ -1,9 +1,9 @@
 package golibmc
 
-const _Version = "v1.2.1"
+const _Version = "v1.2.1-4-gc3c6500"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
-const _Date = "Wed Mar 13 14:40:14 2019 +0800"
+const _Date = "Tue Jul 30 14:06:44 2019 +0800"
 
 // Version of the package
 const Version = _Version

--- a/tests/test_client.cpp
+++ b/tests/test_client.cpp
@@ -209,6 +209,36 @@ TEST(test_client, test_version) {
   }
 }
 
+TEST(test_client, test_flush_all) {
+  Client* client = newClient(2);
+  if (client == NULL) {
+    hint();
+  } else {
+    broadcast_result_t* results = NULL;
+    size_t nHosts = 0;
+    client->flushAll(&results, &nHosts);
+    // The feature is disabled by default,
+    // so no hosts are flushed
+    ASSERT_EQ(nHosts, 0);
+
+    client->toggleFlushAllFeature(true);
+    client->flushAll(&results, &nHosts);
+    ASSERT_EQ(nHosts, 2);
+
+    for (size_t i = 0; i < nHosts; i++) {
+      broadcast_result_t* r = results + i;
+      ASSERT_TRUE(r->msg_type == MSG_OK);
+    }
+    client->destroyBroadcastResult();
+
+
+    client->toggleFlushAllFeature(false);
+    client->flushAll(&results, &nHosts);
+    ASSERT_EQ(nHosts, 0);
+    delete client;
+  }
+}
+
 
 TEST(test_client, test_stats) {
   Client* client = newClient(1);


### PR DESCRIPTION
This PR is to resolve https://github.com/douban/libmc/issues/100 .

To test the feature locally:

- Golang: `go test -test.run TestFlushAll`
- Python: `python setup.py test -a "-k test_flush_all -s"`
- C++: `make test`