### PR TITLE
unittest: fix no pickle

### DIFF
--- a/tests/test_cmemcached_regression.py
+++ b/tests/test_cmemcached_regression.py
@@ -39,6 +39,9 @@ class NoPickle(object):
     def __getattr__(self, name):
         pass
 
+    def __getstate__(self):
+        raise Exception('can not be pickled')
+
 
 class CmemcachedRegressionCase(unittest.TestCase):
 


### PR DESCRIPTION
the old `NoPickle` can be pickled since Python 3.11.
raise error in `__getstate__` to fail pickle.

on Python 3.10:

    Python 3.10.7 (main, Oct 12 2022, 15:33:27) [GCC 9.4.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import pickle
    >>> class OldNoPickle(object):
    ...     def __getattr__(self, name):
    ...         pass
    ... 
    >>> v1 = OldNoPickle()
    >>> pickle.dumps(v1, 2)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: 'NoneType' object is not callable
    >>> class NoPickle(object):
    ...     def __getattr__(self, name):
    ...         pass
    ...     def __getstate__(self):
    ...         raise Exception('can not be pickled')
    ... 
    >>> v2 = NoPickle()
    >>> pickle.dumps(v2, 2)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "<stdin>", line 5, in __getstate__
    Exception: can not be pickled

on Python 3.11:

    Python 3.11.1 (main, Jan 16 2023, 17:53:09) [GCC 9.4.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import pickle
    >>> class OldNoPickle(object):
    ...     def __getattr__(self, name):
    ...         pass
    ... 
    >>> v1 = OldNoPickle()
    >>> pickle.dumps(v1, 2)
    b'\x80\x02c__main__\nOldNoPickle\nq\x00)\x81q\x01.'
    >>> class NoPickle(object):
    ...     def __getattr__(self, name):
    ...         pass
    ...     def __getstate__(self):
    ...         raise Exception('can not be pickled')
    ... 
    >>> v2 = NoPickle()
    >>> pickle.dumps(v2, 2)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "<stdin>", line 5, in __getstate__
    Exception: can not be pickled
