### PR TITLE
fix ci for setuptools 72

### DIFF
--- a/misc/travis/unittest.sh
+++ b/misc/travis/unittest.sh
@@ -9,6 +9,7 @@ cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DWITH_TESTING=ON  ..
 make -j8
 valgrind --leak-check=full make test
 cd ..
-python setup.py test
+python setup.py build_ext --inplace
+python -m pytest tests
 pip install -e .
 ./tests/shabby/run_test.sh

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,12 @@ from __future__ import print_function
 import os
 import re
 import sys
-import shlex
 import pkg_resources
 import platform
 from distutils.sysconfig import get_config_var
 from distutils.version import LooseVersion
 from glob import glob
 from setuptools import setup, Extension
-from setuptools.command.test import test as TestCommand
 
 sources = (glob("src/*.cpp") + ["libmc/_client.pyx"])
 include_dirs = ["include"]
@@ -74,25 +72,6 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = 'tests'
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(shlex.split(self.pytest_args))
-        sys.exit(errno)
-
-
 setup(
     name="libmc",
     packages=["libmc"],
@@ -122,7 +101,6 @@ setup(
     ],
     # Support for the basestring type is new in Cython 0.20.
     setup_requires=["Cython >= 0.20"],
-    cmdclass={"test": PyTest},
     ext_modules=[
         Extension(
             "libmc._client",


### PR DESCRIPTION
setuptools 72.0.0, which released about 7 hours ago, has removed `setuptools.command.test` module.
ref: pypa/setuptools#4458, pypa/setuptools#4518, pypa/setuptools#4519

So I removed pytest from setup.py, and used a `pytest` command instead of `python setup.py test`.

fix:

    Traceback (most recent call last):
      File "/home/runner/work/libmc/libmc/setup.py", line 12, in <module>
        from setuptools.command.test import test as TestCommand
    ModuleNotFoundError: No module named 'setuptools.command.test'