### PR TITLE
bump version 1.4.6

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -33,8 +33,8 @@ from ._client import (
     __file__ as _libmc_so_file
 )
 
-__VERSION__ = "1.4.4"
-__version__ = "1.4.5"
+__VERSION__ = "1.4.6"
+__version__ = "1.4.6"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
 __date__ = "Fri Jun  7 06:16:00 2024 +0800"

--- a/src/version.go
+++ b/src/version.go
@@ -1,6 +1,6 @@
 package golibmc
 
-const _Version = "1.4.5"
+const _Version = "1.4.6"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
 const _Date = "Fri Jun  7 06:16:00 2024 +0800"


### PR DESCRIPTION
version 1.4.5 is wasted, see: https://github.com/douban/libmc/actions/runs/10155292096/job/28081806896

So bump version, and will release 1.4.6.