### PR TITLE
fix wheel for pypy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
       run: python -m pip install cibuildwheel==2.21.3
 
     - name: Build wheels
+      env:
+        CIBW_BEFORE_BUILD: pip install 'setuptools<72.2.0 ; implementation_name == "pypy"'
       run: python -m cibuildwheel --output-dir wheelhouse
     - name: Check build result
       run: ls -lh wheelhouse/

--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -33,8 +33,8 @@ from ._client import (
     __file__ as _libmc_so_file
 )
 
-__VERSION__ = "1.4.7"
-__version__ = "1.4.7"
+__VERSION__ = "1.4.8"
+__version__ = "1.4.8"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
 __date__ = "Fri Jun  7 06:16:00 2024 +0800"

--- a/src/version.go
+++ b/src/version.go
@@ -1,6 +1,6 @@
 package golibmc
 
-const _Version = "1.4.7"
+const _Version = "1.4.8"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
 const _Date = "Fri Jun  7 06:16:00 2024 +0800"


### PR DESCRIPTION
fix error when build wheel for PyPy:

    Traceback (most recent call last):
      File "/opt/python/pp38-pypy38_pp73/lib/pypy3.8/site-packages/setuptools/_distutils/unixccompiler.py", line 269, in link
        self.linker_exe
    TypeError: 'NoneType' object is not subscriptable (key slice(None, None, None))

ref: pypa/cibuildwheel#2015, pypa/distutils#283