### PR TITLE
Fix libmc build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "Topic :: Software Development :: Libraries",
     ],
     # Support for the basestring type is new in Cython 0.20.
-    setup_requires=["Cython >= 0.20"],
+    setup_requires=["Cython >= 0.20, < 3.1"],
     ext_modules=[
         Extension(
             "libmc._client",


### PR DESCRIPTION
In a python 3 environment, libmc fail to be built with Cython 3.1. Adding `< 3.1` restriction fixes the following error.

<details>

<summary>Error compiling Cython file:</summary>

```
Building wheel for libmc (pyproject.toml): started
Building wheel for libmc (pyproject.toml): finished with status 'error'
error: subprocess-exited-with-error

× Building wheel for libmc (pyproject.toml) did not run successfully.

...

running bdist_wheel
running build
running build_py
creating build/lib.macosx-12.0-arm64-cpython-313/libmc
copying libmc/__init__.py -> build/lib.macosx-12.0-arm64-cpython-313/libmc
running build_ext

Error compiling Cython file:
------------------------------------------------------------
...
from libcpp cimport bool as bool_t
from libcpp.string cimport string
from libcpp.vector cimport vector
from cpython.mem cimport PyMem_Malloc, PyMem_Free
from cpython.version cimport PY_MAJOR_VERSION
from cpython cimport Py_INCREF, Py_DECREF, PyInt_AsLong, PyInt_FromLong
^
------------------------------------------------------------

libmc/_client.pyx:11:0: 'cpython/PyInt_AsLong.pxd' not found

Error compiling Cython file:
------------------------------------------------------------
...
from libcpp cimport bool as bool_t
from libcpp.string cimport string
from libcpp.vector cimport vector
from cpython.mem cimport PyMem_Malloc, PyMem_Free
from cpython.version cimport PY_MAJOR_VERSION
from cpython cimport Py_INCREF, Py_DECREF, PyInt_AsLong, PyInt_FromLong
^
------------------------------------------------------------

libmc/_client.pyx:11:0: 'cpython/PyInt_FromLong.pxd' not found

Error compiling Cython file:
------------------------------------------------------------
...
from cpython.mem cimport PyMem_Malloc, PyMem_Free
from cpython.version cimport PY_MAJOR_VERSION
from cpython cimport Py_INCREF, Py_DECREF, PyInt_AsLong, PyInt_FromLong

if PY_MAJOR_VERSION < 3:
    from cpython cimport PyString_AsStringAndSize, PyString_AsString
    ^
------------------------------------------------------------

libmc/_client.pyx:14:4: 'cpython/PyString_AsStringAndSize.pxd' not found

Error compiling Cython file:
------------------------------------------------------------
...
from cpython.mem cimport PyMem_Malloc, PyMem_Free
from cpython.version cimport PY_MAJOR_VERSION
from cpython cimport Py_INCREF, Py_DECREF, PyInt_AsLong, PyInt_FromLong

if PY_MAJOR_VERSION < 3:
    from cpython cimport PyString_AsStringAndSize, PyString_AsString
    ^
------------------------------------------------------------

libmc/_client.pyx:14:4: 'cpython/PyString_AsString.pxd' not found

Error compiling Cython file:
------------------------------------------------------------
...

cdef flags_t _FLAG_DOUBAN_CHUNKED = 1 << 12
cdef int _DOUBAN_CHUNK_SIZE = 1000000


MC_DEFAULT_EXPTIME = PyInt_FromLong(DEFAULT_EXPTIME)
                      ^
------------------------------------------------------------

libmc/_client.pyx:228:21: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
cdef flags_t _FLAG_DOUBAN_CHUNKED = 1 << 12
cdef int _DOUBAN_CHUNK_SIZE = 1000000


MC_DEFAULT_EXPTIME = PyInt_FromLong(DEFAULT_EXPTIME)
MC_POLL_TIMEOUT = PyInt_FromLong(CFG_POLL_TIMEOUT)
                  ^
------------------------------------------------------------

libmc/_client.pyx:229:18: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
cdef int _DOUBAN_CHUNK_SIZE = 1000000


MC_DEFAULT_EXPTIME = PyInt_FromLong(DEFAULT_EXPTIME)
MC_POLL_TIMEOUT = PyInt_FromLong(CFG_POLL_TIMEOUT)
MC_CONNECT_TIMEOUT = PyInt_FromLong(CFG_CONNECT_TIMEOUT)
                      ^
------------------------------------------------------------

libmc/_client.pyx:230:21: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...


MC_DEFAULT_EXPTIME = PyInt_FromLong(DEFAULT_EXPTIME)
MC_POLL_TIMEOUT = PyInt_FromLong(CFG_POLL_TIMEOUT)
MC_CONNECT_TIMEOUT = PyInt_FromLong(CFG_CONNECT_TIMEOUT)
MC_RETRY_TIMEOUT = PyInt_FromLong(CFG_RETRY_TIMEOUT)
                    ^
------------------------------------------------------------

libmc/_client.pyx:231:19: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...

MC_DEFAULT_EXPTIME = PyInt_FromLong(DEFAULT_EXPTIME)
MC_POLL_TIMEOUT = PyInt_FromLong(CFG_POLL_TIMEOUT)
MC_CONNECT_TIMEOUT = PyInt_FromLong(CFG_CONNECT_TIMEOUT)
MC_RETRY_TIMEOUT = PyInt_FromLong(CFG_RETRY_TIMEOUT)
MC_MAX_RETRIES = PyInt_FromLong(CFG_MAX_RETRIES)
                  ^
------------------------------------------------------------

libmc/_client.pyx:232:17: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_CONNECT_TIMEOUT = PyInt_FromLong(CFG_CONNECT_TIMEOUT)
MC_RETRY_TIMEOUT = PyInt_FromLong(CFG_RETRY_TIMEOUT)
MC_MAX_RETRIES = PyInt_FromLong(CFG_MAX_RETRIES)


MC_HASH_MD5 = PyInt_FromLong(OPT_HASH_MD5)
              ^
------------------------------------------------------------

libmc/_client.pyx:235:14: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_RETRY_TIMEOUT = PyInt_FromLong(CFG_RETRY_TIMEOUT)
MC_MAX_RETRIES = PyInt_FromLong(CFG_MAX_RETRIES)


MC_HASH_MD5 = PyInt_FromLong(OPT_HASH_MD5)
MC_HASH_FNV1_32 = PyInt_FromLong(OPT_HASH_FNV1_32)
                  ^
------------------------------------------------------------

libmc/_client.pyx:236:18: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_MAX_RETRIES = PyInt_FromLong(CFG_MAX_RETRIES)


MC_HASH_MD5 = PyInt_FromLong(OPT_HASH_MD5)
MC_HASH_FNV1_32 = PyInt_FromLong(OPT_HASH_FNV1_32)
MC_HASH_FNV1A_32 = PyInt_FromLong(OPT_HASH_FNV1A_32)
                    ^
------------------------------------------------------------

libmc/_client.pyx:237:19: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...


MC_HASH_MD5 = PyInt_FromLong(OPT_HASH_MD5)
MC_HASH_FNV1_32 = PyInt_FromLong(OPT_HASH_FNV1_32)
MC_HASH_FNV1A_32 = PyInt_FromLong(OPT_HASH_FNV1A_32)
MC_HASH_CRC_32 = PyInt_FromLong(OPT_HASH_CRC_32)
                  ^
------------------------------------------------------------

libmc/_client.pyx:238:17: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_HASH_FNV1_32 = PyInt_FromLong(OPT_HASH_FNV1_32)
MC_HASH_FNV1A_32 = PyInt_FromLong(OPT_HASH_FNV1A_32)
MC_HASH_CRC_32 = PyInt_FromLong(OPT_HASH_CRC_32)


MC_RETURN_SEND_ERR = PyInt_FromLong(RET_SEND_ERR)
                      ^
------------------------------------------------------------

libmc/_client.pyx:241:21: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_HASH_FNV1A_32 = PyInt_FromLong(OPT_HASH_FNV1A_32)
MC_HASH_CRC_32 = PyInt_FromLong(OPT_HASH_CRC_32)


MC_RETURN_SEND_ERR = PyInt_FromLong(RET_SEND_ERR)
MC_RETURN_RECV_ERR = PyInt_FromLong(RET_RECV_ERR)
                      ^
------------------------------------------------------------

libmc/_client.pyx:242:21: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_HASH_CRC_32 = PyInt_FromLong(OPT_HASH_CRC_32)


MC_RETURN_SEND_ERR = PyInt_FromLong(RET_SEND_ERR)
MC_RETURN_RECV_ERR = PyInt_FromLong(RET_RECV_ERR)
MC_RETURN_CONN_POLL_ERR = PyInt_FromLong(RET_CONN_POLL_ERR)
                          ^
------------------------------------------------------------

libmc/_client.pyx:243:26: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...


MC_RETURN_SEND_ERR = PyInt_FromLong(RET_SEND_ERR)
MC_RETURN_RECV_ERR = PyInt_FromLong(RET_RECV_ERR)
MC_RETURN_CONN_POLL_ERR = PyInt_FromLong(RET_CONN_POLL_ERR)
MC_RETURN_POLL_TIMEOUT_ERR = PyInt_FromLong(RET_POLL_TIMEOUT_ERR)
                              ^
------------------------------------------------------------

libmc/_client.pyx:244:29: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...

MC_RETURN_SEND_ERR = PyInt_FromLong(RET_SEND_ERR)
MC_RETURN_RECV_ERR = PyInt_FromLong(RET_RECV_ERR)
MC_RETURN_CONN_POLL_ERR = PyInt_FromLong(RET_CONN_POLL_ERR)
MC_RETURN_POLL_TIMEOUT_ERR = PyInt_FromLong(RET_POLL_TIMEOUT_ERR)
MC_RETURN_POLL_ERR = PyInt_FromLong(RET_POLL_ERR)
                      ^
------------------------------------------------------------

libmc/_client.pyx:245:21: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_RETURN_SEND_ERR = PyInt_FromLong(RET_SEND_ERR)
MC_RETURN_RECV_ERR = PyInt_FromLong(RET_RECV_ERR)
MC_RETURN_CONN_POLL_ERR = PyInt_FromLong(RET_CONN_POLL_ERR)
MC_RETURN_POLL_TIMEOUT_ERR = PyInt_FromLong(RET_POLL_TIMEOUT_ERR)
MC_RETURN_POLL_ERR = PyInt_FromLong(RET_POLL_ERR)
MC_RETURN_MC_SERVER_ERR = PyInt_FromLong(RET_MC_SERVER_ERR)
                          ^
------------------------------------------------------------

libmc/_client.pyx:246:26: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_RETURN_RECV_ERR = PyInt_FromLong(RET_RECV_ERR)
MC_RETURN_CONN_POLL_ERR = PyInt_FromLong(RET_CONN_POLL_ERR)
MC_RETURN_POLL_TIMEOUT_ERR = PyInt_FromLong(RET_POLL_TIMEOUT_ERR)
MC_RETURN_POLL_ERR = PyInt_FromLong(RET_POLL_ERR)
MC_RETURN_MC_SERVER_ERR = PyInt_FromLong(RET_MC_SERVER_ERR)
MC_RETURN_PROGRAMMING_ERR = PyInt_FromLong(RET_PROGRAMMING_ERR)
                            ^
------------------------------------------------------------

libmc/_client.pyx:247:28: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_RETURN_CONN_POLL_ERR = PyInt_FromLong(RET_CONN_POLL_ERR)
MC_RETURN_POLL_TIMEOUT_ERR = PyInt_FromLong(RET_POLL_TIMEOUT_ERR)
MC_RETURN_POLL_ERR = PyInt_FromLong(RET_POLL_ERR)
MC_RETURN_MC_SERVER_ERR = PyInt_FromLong(RET_MC_SERVER_ERR)
MC_RETURN_PROGRAMMING_ERR = PyInt_FromLong(RET_PROGRAMMING_ERR)
MC_RETURN_INVALID_KEY_ERR = PyInt_FromLong(RET_INVALID_KEY_ERR)
                            ^
------------------------------------------------------------

libmc/_client.pyx:248:28: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_RETURN_POLL_TIMEOUT_ERR = PyInt_FromLong(RET_POLL_TIMEOUT_ERR)
MC_RETURN_POLL_ERR = PyInt_FromLong(RET_POLL_ERR)
MC_RETURN_MC_SERVER_ERR = PyInt_FromLong(RET_MC_SERVER_ERR)
MC_RETURN_PROGRAMMING_ERR = PyInt_FromLong(RET_PROGRAMMING_ERR)
MC_RETURN_INVALID_KEY_ERR = PyInt_FromLong(RET_INVALID_KEY_ERR)
MC_RETURN_INCOMPLETE_BUFFER_ERR = PyInt_FromLong(RET_INCOMPLETE_BUFFER_ERR)
                                  ^
------------------------------------------------------------

libmc/_client.pyx:249:34: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
MC_RETURN_POLL_ERR = PyInt_FromLong(RET_POLL_ERR)
MC_RETURN_MC_SERVER_ERR = PyInt_FromLong(RET_MC_SERVER_ERR)
MC_RETURN_PROGRAMMING_ERR = PyInt_FromLong(RET_PROGRAMMING_ERR)
MC_RETURN_INVALID_KEY_ERR = PyInt_FromLong(RET_INVALID_KEY_ERR)
MC_RETURN_INCOMPLETE_BUFFER_ERR = PyInt_FromLong(RET_INCOMPLETE_BUFFER_ERR)
MC_RETURN_OK = PyInt_FromLong(RET_OK)
                ^
------------------------------------------------------------

libmc/_client.pyx:250:15: 'PyInt_FromLong' is not a constant, variable or function identifier

Error compiling Cython file:
------------------------------------------------------------
...
        flags[0] = _FLAG_BOOL
        enc_val = b'1' if val else b'0'
    elif type_ is int:
        flags[0] = _FLAG_INTEGER
        enc_val = str(val).encode('ascii')
    elif type_ is long:
                  ^
------------------------------------------------------------

libmc/_client.pyx:266:18: undeclared name not builtin: long

Error compiling Cython file:
------------------------------------------------------------
...

        Py_INCREF(servers_)
        for i in range(n):
            host, port, alias = servers_[i]
            c_hosts[i] = PyString_AsString(host)
            c_ports[i] = PyInt_AsLong(port)
                          ^
------------------------------------------------------------

libmc/_client.pyx:403:25: 'PyInt_AsLong' is not a constant, variable or function identifier
Compiling libmc/_client.pyx because it changed.
```

</details>