### PR TITLE
fix decode value

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -33,8 +33,8 @@ from ._client import (
     __file__ as _libmc_so_file
 )
 
-__VERSION__ = "1.4.11"
-__version__ = "1.4.11"
+__VERSION__ = "1.4.12"
+__version__ = "1.4.12"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
 __date__ = "Fri Jun  7 06:16:00 2024 +0800"

--- a/libmc/_client.pyx
+++ b/libmc/_client.pyx
@@ -16,7 +16,6 @@ from cpython cimport (
     PyBytes_AsString as PyString_AsString,
     PyUnicode_AsUTF8String,
 )
-from ctypes import c_long as long
 
 import os
 import sys
@@ -299,9 +298,6 @@ cdef bytes _encode_value(object val, int comp_threshold, flags_t *flags):
         flags[0] = _FLAG_BOOL
         enc_val = b'1' if val else b'0'
     elif type_ is int:
-        flags[0] = _FLAG_INTEGER
-        enc_val = str(val).encode('ascii')
-    elif type_ is long:
         flags[0] = _FLAG_LONG
         enc_val = str(val).encode('ascii')
     elif type_.__module__ == 'numpy':
@@ -346,7 +342,7 @@ cpdef object decode_value(bytes val, flags_t flags):
     elif flags & _FLAG_INTEGER:
         dec_val = int(dec_val.decode('ascii'))
     elif flags & _FLAG_LONG:
-        dec_val = long(dec_val.decode('ascii'))
+        dec_val = int(dec_val.decode('ascii'))
     elif flags & _FLAG_MARSHAL:
         try:
             dec_val = marshal.loads(dec_val)

--- a/src/version.go
+++ b/src/version.go
@@ -1,6 +1,6 @@
 package golibmc
 
-const _Version = "1.4.11"
+const _Version = "1.4.12"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
 const _Date = "Fri Jun  7 06:16:00 2024 +0800"


### PR DESCRIPTION
fix:

    >   dec_val = long(dec_val.decode('ascii'))
    E   TypeError: 'str' object cannot be interpreted as an integer
    libmc/_client.pyx:349: TypeError