### PR TITLE
remove version limit of Cython

### DIFF
--- a/libmc/__init__.py
+++ b/libmc/__init__.py
@@ -33,8 +33,8 @@ from ._client import (
     __file__ as _libmc_so_file
 )
 
-__VERSION__ = "1.4.12"
-__version__ = "1.4.12"
+__VERSION__ = "1.4.13"
+__version__ = "1.4.13"
 __author__ = "mckelvin"
 __email__ = "mckelvin@users.noreply.github.com"
 __date__ = "Fri Jun  7 06:16:00 2024 +0800"

--- a/setup.py
+++ b/setup.py
@@ -101,12 +101,7 @@ setup(
     ],
     setup_requires=[
         # Support for the basestring type is new in Cython 0.20.
-        'Cython >= 0.20 ; implementation_name != "pypy"',
-        'Cython >= 0.20 ; implementation_name == "pypy" and python_version > "3.8"',
-
-        # compile error in PyPy 3.8 with Cython 3.1.2
-        # error: 'PyDescr_NewMember' was not declared in this scope
-        'Cython >= 0.20, < 3.1; implementation_name == "pypy" and python_version <= "3.8"',
+        'Cython >= 0.20',
     ],
     ext_modules=[
         Extension(

--- a/src/version.go
+++ b/src/version.go
@@ -1,6 +1,6 @@
 package golibmc
 
-const _Version = "1.4.12"
+const _Version = "1.4.13"
 const _Author = "mckelvin"
 const _Email = "mckelvin@users.noreply.github.com"
 const _Date = "Fri Jun  7 06:16:00 2024 +0800"


### PR DESCRIPTION
Cython has fixed the bug about PyPy 3.8 and released 3.1.3 yesterday (Aug 13, 2025).

ref: #139